### PR TITLE
Implement simple packet size limiting with file chunking

### DIFF
--- a/cmd/enigma-sensor/main.go
+++ b/cmd/enigma-sensor/main.go
@@ -138,7 +138,7 @@ func main() {
 		if server == "" || apiKey == "" {
 			log.Printf("enigma_api.server and enigma_api.api_key must be set to upload logs; skipping upload.")
 		} else {
-			u, err := api.NewLogUploader(server, apiKey)
+			u, err := api.NewLogUploader(server, apiKey, cfg.EnigmaAPI.MaxPayloadSizeMB)
 			if err != nil {
 				log.Printf("Failed to initialize LogUploader: %v", err)
 			} else {

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,8 @@ type Config struct {
 		APIKey string `json:"api_key"`
 		// Upload is whether to upload captured data to the Enigma API
 		Upload bool `json:"upload"`
+		// MaxPayloadSizeMB is the maximum size of payload before chunking (default: 25MB)
+		MaxPayloadSizeMB int64 `json:"max_payload_size_mb"`
 	} `json:"enigma_api"`
 
 	// Zeek configuration
@@ -85,6 +87,9 @@ func LoadConfig(configPath string) (*Config, error) {
 	}
 	if config.EnigmaAPI.Upload == false {
 		config.EnigmaAPI.Upload = false
+	}
+	if config.EnigmaAPI.MaxPayloadSizeMB == 0 {
+		config.EnigmaAPI.MaxPayloadSizeMB = 25 // 25MB default
 	}
 	if config.Capture.Loop != true {
 		config.Capture.Loop = false

--- a/internal/sensor/sensor_test.go
+++ b/internal/sensor/sensor_test.go
@@ -97,9 +97,10 @@ func minimalConfig(loop bool) *config.Config {
 			LogRetentionDays: 1,
 		},
 		EnigmaAPI: struct {
-			Server string `json:"server"`
-			APIKey string `json:"api_key"`
-			Upload bool   `json:"upload"`
+			Server           string `json:"server"`
+			APIKey           string `json:"api_key"`
+			Upload           bool   `json:"upload"`
+			MaxPayloadSizeMB int64  `json:"max_payload_size_mb"`
 		}{},
 	}
 }


### PR DESCRIPTION
- Add max_payload_size_mb configuration option (default: 25MB)
- Check total file size before upload and chunk if needed
- Split CSV files at line boundaries preserving headers
- Upload each chunk separately using existing mechanism
- Clean up temporary chunk files after upload
- Add comprehensive tests for chunking functionality

This simple approach prevents OOM errors by breaking large files into smaller chunks when they exceed the threshold.

Ref B1CF-562