### PR TITLE
Fix Windows sensor ETL file not found during pktmon conversion

### DIFF
--- a/internal/capture/windows/capture.go
+++ b/internal/capture/windows/capture.go
@@ -45,31 +45,48 @@ func (c *WindowsCapturer) Capture(ctx context.Context, config common.CaptureConf
 func (c *WindowsCapturer) runCapture(ctx context.Context, config common.CaptureConfig) (string, error) {
 	// Generate output filename with timestamp
 	timestamp := time.Now().Format("20060102_150405")
-	etlFile := fmt.Sprintf("%s/capture_%s.etl", c.outputDir, timestamp)
+	etlFile := filepath.Join(c.outputDir, fmt.Sprintf("capture_%s.etl", timestamp))
 
 	if config.Interface != "" && config.Interface != "any" && config.Interface != "all" {
+		log.Printf("[capture] Adding pktmon filter for interface: %s", config.Interface)
 		addCmd := commandContext("pktmon", "filter", "add", "-i", config.Interface)
 		if err := addCmd.Run(); err != nil {
-			return "", fmt.Errorf("failed to add pktmon filter: %v", err)
+			return "", fmt.Errorf("failed to add pktmon filter for interface %s: %v", config.Interface, err)
 		}
-		defer commandContext("pktmon", "filter", "remove").Run()
+		defer func() {
+			log.Printf("[capture] Removing pktmon filter")
+			if err := commandContext("pktmon", "filter", "remove").Run(); err != nil {
+				log.Printf("[capture] Warning: failed to remove pktmon filter: %v", err)
+			}
+		}()
 	}
 
 	// Start pktmon capture
-	log.Printf("[capture] Running pktmon command: pktmon start --capture --file %s", etlFile)
+	log.Printf("[capture] Starting pktmon capture with command: pktmon start --capture --file %s", etlFile)
 	c.cmd = commandContext("pktmon", "start", "--capture", "--file", etlFile)
 
 	if err := c.cmd.Start(); err != nil {
-		return "", fmt.Errorf("failed to start pktmon: %v", err)
+		return "", fmt.Errorf("failed to start pktmon capture: %v", err)
 	}
+	log.Printf("[capture] pktmon capture started successfully")
 
 	// Wait for capture duration
+	log.Printf("[capture] Capturing for %v...", config.CaptureWindow)
 	time.Sleep(config.CaptureWindow)
 
 	// Stop capture
+	log.Printf("[capture] Stopping pktmon capture")
 	stopCmd := commandContext("pktmon", "stop")
 	if err := stopCmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to stop pktmon: %v", err)
+		return "", fmt.Errorf("failed to stop pktmon capture: %v", err)
+	}
+	log.Printf("[capture] pktmon capture stopped successfully")
+
+	// Verify ETL file exists before attempting conversion
+	// Add retry logic to handle timing race conditions
+	log.Printf("[capture] Verifying ETL file exists: %s", etlFile)
+	if err := waitForETLFile(etlFile, 5*time.Second); err != nil {
+		return "", fmt.Errorf("ETL file verification failed after pktmon stop: %v", err)
 	}
 
 	// Detect available pktmon conversion subcommand
@@ -79,7 +96,7 @@ func (c *WindowsCapturer) runCapture(ctx context.Context, config common.CaptureC
 	}
 
 	// Convert ETL to PCAPNG
-	pcapngFile := fmt.Sprintf("%s/capture_%s.pcapng", c.outputDir, timestamp)
+	pcapngFile := filepath.Join(c.outputDir, fmt.Sprintf("capture_%s.pcapng", timestamp))
 	log.Printf("[capture] Running conversion: pktmon %s %s -o %s", subcommand, etlFile, pcapngFile)
 	convertCmd := commandContext("pktmon", subcommand, etlFile, "-o", pcapngFile)
 	var outBuf, errBuf bytes.Buffer
@@ -92,6 +109,37 @@ func (c *WindowsCapturer) runCapture(ctx context.Context, config common.CaptureC
 	}
 
 	return pcapngFile, nil
+}
+
+// waitForETLFile waits for the ETL file to exist and be non-empty, with retry logic
+func waitForETLFile(etlFile string, timeout time.Duration) error {
+	start := time.Now()
+	checkInterval := 100 * time.Millisecond
+
+	for time.Since(start) < timeout {
+		if info, err := os.Stat(etlFile); err == nil {
+			// File exists, check if it has content
+			if info.Size() > 0 {
+				log.Printf("[capture] ETL file verified: %s (size: %d bytes)", etlFile, info.Size())
+				return nil
+			}
+			log.Printf("[capture] ETL file exists but is empty, waiting... (size: %d)", info.Size())
+		} else {
+			log.Printf("[capture] ETL file does not exist yet, waiting: %s", etlFile)
+		}
+
+		time.Sleep(checkInterval)
+	}
+
+	// Final check to provide detailed error information
+	if info, err := os.Stat(etlFile); err != nil {
+		return fmt.Errorf("ETL file '%s' does not exist after %v timeout: %v", etlFile, timeout, err)
+	} else if info.Size() == 0 {
+		return fmt.Errorf("ETL file '%s' exists but is empty after %v timeout (possible pktmon capture failure)", etlFile, timeout)
+	} else {
+		// This shouldn't happen, but just in case
+		return fmt.Errorf("ETL file '%s' verification failed after %v timeout", etlFile, timeout)
+	}
 }
 
 // detectPktmonConversionSubcommand checks which pktmon conversion subcommand is available.

--- a/internal/capture/windows/capture.go
+++ b/internal/capture/windows/capture.go
@@ -34,7 +34,7 @@ func (c *WindowsCapturer) Capture(ctx context.Context, config common.CaptureConf
 	if err == nil {
 		for _, entry := range entries {
 			if !entry.IsDir() && filepath.Ext(entry.Name()) == ".etl" {
-				os.Remove(c.outputDir + "/" + entry.Name())
+				os.Remove(filepath.Join(c.outputDir, entry.Name()))
 			}
 		}
 	}

--- a/internal/capture/windows/capture_test.go
+++ b/internal/capture/windows/capture_test.go
@@ -4,6 +4,7 @@ package windows
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -68,4 +69,141 @@ func TestWindowsCapturer_Capture_Error(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error, got nil")
 	}
+}
+
+// TestWindowsCapturer_ETL_File_Not_Found reproduces the B1CF-431 issue where ETL file doesn't exist during conversion
+func TestWindowsCapturer_ETL_File_Not_Found(t *testing.T) {
+	c := NewWindowsCapturer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use a Windows-style output directory that reproduces the path mixing issue from the ticket
+	config := common.CaptureConfig{
+		CaptureWindow: 1 * time.Second,
+		OutputDir:     "captures\\zeek_out_20250616T175905Z", // Windows-style path from ticket
+		Interface:     "any",
+	}
+
+	origCommandContext := commandContext
+	callCount := 0
+	commandContext = func(name string, arg ...string) *exec.Cmd {
+		callCount++
+
+		// Mock pktmon start/stop to succeed but NOT create the ETL file
+		if name == "pktmon" && len(arg) > 0 {
+			switch arg[0] {
+			case "start":
+				// Simulate pktmon start succeeding but silently failing to create ETL
+				return exec.Command("cmd", "/C", "echo", "pktmon start succeeded")
+			case "stop":
+				// Simulate pktmon stop succeeding
+				return exec.Command("cmd", "/C", "echo", "pktmon stop succeeded")
+			case "etl2pcapng", "etl2pcap":
+				// This should not be reached now because our fix checks file existence first
+				if len(arg) >= 3 {
+					etlPath := arg[1]
+					t.Logf("Attempting to convert ETL file: %s", etlPath)
+					// This should fail with file not found since we didn't create the ETL
+					return exec.Command("cmd", "/C", "echo Cannot open file '"+etlPath+"': The system cannot find the file specified & exit 2")
+				}
+			}
+		}
+
+		// For detection commands, return success
+		return exec.Command("cmd", "/C", "echo")
+	}
+	defer func() { commandContext = origCommandContext }()
+
+	// This should now fail during ETL file verification, not during conversion
+	_, err := c.Capture(ctx, config)
+
+	// Verify we get the expected "ETL file verification failed" error instead of "failed to convert ETL to PCAPNG"
+	if err == nil {
+		t.Errorf("Expected error due to ETL file verification, got nil")
+	} else {
+		expectedErrMsg := "ETL file verification failed"
+		if !containsString(err.Error(), expectedErrMsg) {
+			t.Errorf("Expected error containing '%s', got: %v", expectedErrMsg, err)
+		} else {
+			t.Logf("Fix working correctly - failing at verification stage instead of conversion: %v", err)
+		}
+	}
+}
+
+// TestWindowsCapturer_With_Fix_Success tests that the fix works when ETL file is properly created
+func TestWindowsCapturer_With_Fix_Success(t *testing.T) {
+	c := NewWindowsCapturer()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	config := common.CaptureConfig{
+		CaptureWindow: 1 * time.Second,
+		OutputDir:     tempDir,
+		Interface:     "any",
+	}
+
+	origCommandContext := commandContext
+	var etlFilePath string
+	commandContext = func(name string, arg ...string) *exec.Cmd {
+		if name == "pktmon" && len(arg) > 0 {
+			switch arg[0] {
+			case "start":
+				// Extract ETL file path from arguments and create a dummy file
+				for i, a := range arg {
+					if a == "--file" && i+1 < len(arg) {
+						etlFilePath = arg[i+1]
+						// Create the ETL file with some dummy content
+						go func() {
+							time.Sleep(200 * time.Millisecond) // Simulate file creation delay
+							if err := os.WriteFile(etlFilePath, []byte("dummy ETL content"), 0644); err != nil {
+								t.Logf("Failed to create dummy ETL file: %v", err)
+							}
+						}()
+						break
+					}
+				}
+				return exec.Command("echo", "pktmon start succeeded")
+			case "stop":
+				return exec.Command("echo", "pktmon stop succeeded")
+			case "etl2pcapng", "etl2pcap":
+				if len(arg) >= 3 {
+					// Create a dummy PCAPNG file to simulate successful conversion
+					pcapngPath := arg[len(arg)-1] // Last argument is output file
+					if err := os.WriteFile(pcapngPath, []byte("dummy PCAPNG content"), 0644); err != nil {
+						t.Logf("Failed to create dummy PCAPNG file: %v", err)
+					}
+					return exec.Command("echo", "conversion succeeded")
+				}
+			}
+		}
+
+		// For detection commands, return success
+		return exec.Command("echo")
+	}
+	defer func() { commandContext = origCommandContext }()
+
+	// This should now succeed with our fixes
+	result, err := c.Capture(ctx, config)
+
+	if err != nil {
+		t.Errorf("Expected successful capture with fixes, got error: %v", err)
+	} else {
+		t.Logf("Capture succeeded with result: %s", result)
+		// Verify the result path uses proper path separators
+		if result == "" {
+			t.Errorf("Expected non-empty result path")
+		}
+	}
+}
+
+// Helper function to check if a string contains a substring
+func containsString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
- Add waitForETLFile() function with 5-second timeout and retry logic
- Fix path separator issues using filepath.Join() throughout
- Enhance error handling and logging for pktmon operations
- Add comprehensive tests reproducing B1CF-431 issue and verifying fix
- Ensure robust file existence validation before ETL to PCAP conversion

Ref B1CF-431