### PR TITLE
Add local buffering with flush and retention; centralize config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ You can send this archive to Enigma support for troubleshooting.
   - `logging`: Log level, file path, and max size.
   - `capture`: Output directory, interval, window duration, and interface.
   - `enigma_api`: API server, API key, upload toggle (always enabled).
+  - `buffering`: Local buffering directory and max age for retrying uploads.
   - `zeek`: Traffic sampling configuration.
   - `log_retention_days`: Number of days to keep log files. Logs older than this are deleted on startup. Default: 1
 - **How to configure:**
@@ -130,6 +131,24 @@ The sensor supports automatic log rotation and compression. Configure these opti
 - Up to 3 rotated log files are kept by default.
 - Rotated logs older than `log_retention_days` are deleted automatically.
 - All logs are also output to stdout for convenience.
+
+---
+
+### Buffering During API Outages
+
+The sensor buffers uploads locally when the publisher API is temporarily unavailable (e.g., 500/503 or gRPC Unavailable). Buffered payloads are retried automatically and purged after a time limit.
+
+```json
+"buffering": {
+  "dir": "logs/buffer",   // Directory for buffered payloads
+  "max_age_hours": 2       // Purge buffered items older than this many hours
+}
+```
+
+- On each upload attempt, the sensor first flushes any buffered payloads (oldest first).
+- If upload fails after retries, the current payload is saved to the buffer.
+- Items older than `max_age_hours` are purged automatically to prevent disk growth.
+- A 410 Gone response is treated as terminal and is not buffered.
 
 ---
 

--- a/cmd/enigma-sensor/main.go
+++ b/cmd/enigma-sensor/main.go
@@ -138,7 +138,7 @@ func main() {
 		if server == "" || apiKey == "" {
 			log.Printf("enigma_api.server and enigma_api.api_key must be set to upload logs; skipping upload.")
 		} else {
-			u, err := api.NewLogUploader(server, apiKey, cfg.EnigmaAPI.MaxPayloadSizeMB)
+			u, err := api.NewLogUploader(server, apiKey, cfg.EnigmaAPI.MaxPayloadSizeMB, cfg.Buffering.Dir, cfg.Buffering.MaxAgeHours)
 			if err != nil {
 				log.Printf("Failed to initialize LogUploader: %v", err)
 			} else {

--- a/config.example.json
+++ b/config.example.json
@@ -16,6 +16,10 @@
     "api_key": "REPLACE_WITH_YOUR_API_KEY",
     "upload": false
   },
+  "buffering": {
+    "dir": "logs/buffer",
+    "max_age_hours": 2
+  },
   "zeek": {
     "sampling_percentage": 100
   }

--- a/internal/api/client_buffer_test.go
+++ b/internal/api/client_buffer_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test buffering on temporary errors and flushing on recovery
+func TestLogUploader_BufferAndFlush(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create small test files
+	dnsPath := filepath.Join(tmpDir, "dns.csv")
+	connPath := filepath.Join(tmpDir, "conn.csv")
+	require.NoError(t, os.WriteFile(dnsPath, []byte("h\na\n"), 0600))
+	require.NoError(t, os.WriteFile(connPath, []byte("h\nb\n"), 0600))
+
+	// First call returns 500 (cause buffer), second and third succeed (flush + current)
+	mock := &mockPublishClient{uploadResponses: []uploadResponse{
+		{status: "fail", statusCode: 500, message: "server error", err: nil},
+		{status: "success", statusCode: 200, message: "ok", err: nil},
+		{status: "success", statusCode: 200, message: "ok", err: nil},
+	}}
+
+	uploader := &LogUploader{
+		client:           mock,
+		apiKey:           "k",
+		retryCount:       1,
+		retryDelay:       time.Millisecond,
+		compressFunc:     compressData,
+		maxPayloadSizeMB: 25,
+		bufferDir:        filepath.Join(tmpDir, "buffer"),
+		bufferMaxAge:     2 * time.Hour,
+	}
+
+	// First upload should buffer and return error
+	err := uploader.UploadLogs(context.Background(), LogFiles{DNSPath: dnsPath, ConnPath: connPath})
+	require.Error(t, err)
+
+	// Ensure a buffer file exists
+	entries, err := os.ReadDir(uploader.bufferDir)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(entries), 1)
+
+	// Second upload should flush buffered first, then upload current
+	require.NoError(t, os.WriteFile(connPath, []byte("h\nc\n"), 0600))
+	err = uploader.UploadLogs(context.Background(), LogFiles{DNSPath: dnsPath, ConnPath: connPath})
+	require.NoError(t, err)
+
+	// Buffer dir should be empty after successful flush
+	entries, err = os.ReadDir(uploader.bufferDir)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(entries))
+}
+
+// Test that old buffered files are purged based on max age
+func TestLogUploader_BufferPurgeOld(t *testing.T) {
+	tmpDir := t.TempDir()
+	bufDir := filepath.Join(tmpDir, "buffer")
+	require.NoError(t, os.MkdirAll(bufDir, 0o755))
+
+	uploader := &LogUploader{
+		apiKey:       "k",
+		retryCount:   1,
+		retryDelay:   time.Millisecond,
+		compressFunc: compressData,
+		bufferDir:    bufDir,
+		bufferMaxAge: time.Hour, // 1 hour
+	}
+
+	// Create a fake buffered file and age it
+	f := filepath.Join(bufDir, "buf_20000101T000000Z_1.bin")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+	old := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(f, old, old))
+
+	// Flush should purge the old file even without a client
+	require.NoError(t, uploader.flushBuffer(context.Background()))
+
+	entries, err := os.ReadDir(bufDir)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(entries))
+}


### PR DESCRIPTION
Buffer up to 2 hours (by default) of binary files locally, then flush them in order once the API connection is resolved.

Ref B1CF-630