### PR TITLE
Use config.example.json as single source for Windows installer

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -8,13 +8,13 @@
   "capture": {
     "output_dir": "./captures",
     "window_seconds": 60,
-    "loop": false,
+    "loop": true,
     "interface": "any"
   },
   "enigma_api": {
     "server": "api.enigmaai.net:443",
     "api_key": "REPLACE_WITH_YOUR_API_KEY",
-    "upload": false
+    "upload": true
   },
   "buffering": {
     "dir": "logs/buffer",


### PR DESCRIPTION
- Bundle config.example.json in installer and copy to target location
- Replace API key, loop, and upload values via string replacement
- Remove hardcoded config template from installer script
- Update config.example.json defaults to production-ready values (loop: true, upload: true)
- Eliminates config duplication and maintenance burden