### PR TITLE
Fix retention_hours=0 sweep race that deletes folders before processing

### DIFF
--- a/internal/sensor/sensor.go
+++ b/internal/sensor/sensor.go
@@ -401,10 +401,10 @@ func RunSensor(ctx context.Context, cfg *config.Config, capturer Capturer, proce
 	}
 
 	for {
-		// Clean up old zeek_out_* folders every iteration
-		if cfg.Capture.RetentionHours != nil {
+		// Clean up old zeek_out_* folders every iteration (skip when 0; worker handles immediate cleanup)
+		if cfg.Capture.RetentionHours != nil && *cfg.Capture.RetentionHours > 0 {
 			cleanOldZeekOutFolders(cfg.Capture.OutputDir, *cfg.Capture.RetentionHours)
-		} else {
+		} else if cfg.Capture.RetentionHours == nil {
 			cleanOldZeekOutFolders(cfg.Capture.OutputDir, cfg.Logging.LogRetentionDays*24)
 		}
 		select {


### PR DESCRIPTION
## Summary

- When `retention_hours=0`, skip the periodic sweep entirely; the worker handles immediate cleanup after processing + upload
- When `retention_hours > 0`, sweep deletes folders older than N hours (unchanged)
- When `retention_hours` is nil (not configured), fall back to `log_retention_days` (unchanged from pre-feature behavior)

## Problem

With `retention_hours=0`, the sweep cutoff was `time.Now()`, which deleted zeek_out folders at the top of each loop iteration before workers could process the PCAPs inside them. Zeek would fail with "No such file or directory."

## Verified

Tested locally with Docker (`SENSOR_CAPTURE_RETENTION_HOURS=0`, 6s capture window). Three clean capture/process/upload/cleanup cycles with no premature deletions.

## Test plan

- [x] All existing tests pass
- [x] Docker integration test: retention_hours=0 with 6s capture window, 3 successful cycles