### PR TITLE
B1CF-1643 Add DHCP option 55 capture to sensor for Fingerbank device fingerprin…

### DIFF
--- a/internal/processor/common/dhcp_enrichment.go
+++ b/internal/processor/common/dhcp_enrichment.go
@@ -1,0 +1,149 @@
+package types
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
+)
+
+// EnrichDHCPLog parses DHCP option 55 (parameter request list) from the
+// pcapng file and writes the values into the param_req_list column of the
+// Zeek-generated dhcp.log. Non-fatal: errors are logged and the function
+// returns nil so the main processing path is never interrupted.
+func EnrichDHCPLog(pcapPath, dhcpLogPath string) error {
+	fingerprints, err := ExtractDHCPFingerprints(pcapPath)
+	if err != nil {
+		log.Printf("[processor] Warning: DHCP fingerprint extraction failed: %v", err)
+		return nil
+	}
+	if len(fingerprints) == 0 {
+		return nil
+	}
+	if err := PatchDHCPLog(dhcpLogPath, fingerprints); err != nil {
+		log.Printf("[processor] Warning: DHCP log enrichment failed: %v", err)
+	}
+	return nil
+}
+
+// packetReader is the common interface satisfied by both pcapgo.Reader and pcapgo.NgReader.
+type packetReader interface {
+	gopacket.PacketDataSource
+	LinkType() layers.LinkType
+}
+
+// ExtractDHCPFingerprints reads a pcap or pcapng file and returns a map from
+// client MAC address to comma-separated DHCP option 55 (parameter request list).
+// Only BOOTREQUEST packets are examined; the first fingerprint seen per MAC
+// is kept since option 55 is a stable property of the client OS/stack.
+func ExtractDHCPFingerprints(pcapPath string) (map[string]string, error) {
+	f, err := os.Open(pcapPath)
+	if err != nil {
+		return nil, fmt.Errorf("open pcap: %w", err)
+	}
+	defer f.Close()
+
+	// Try pcapng first (Windows pktmon output); fall back to regular pcap (Linux tcpdump output).
+	var reader packetReader
+	if ngr, err := pcapgo.NewNgReader(f, pcapgo.DefaultNgReaderOptions); err == nil {
+		reader = ngr
+	} else {
+		if _, err := f.Seek(0, 0); err != nil {
+			return nil, fmt.Errorf("seek pcap: %w", err)
+		}
+		r, err := pcapgo.NewReader(f)
+		if err != nil {
+			return nil, fmt.Errorf("pcap reader: %w", err)
+		}
+		reader = r
+	}
+
+	result := make(map[string]string)
+	src := gopacket.NewPacketSource(reader, reader.LinkType())
+	src.DecodeOptions.Lazy = true
+
+	for packet := range src.Packets() {
+		dhcpLayer := packet.Layer(layers.LayerTypeDHCPv4)
+		if dhcpLayer == nil {
+			continue
+		}
+		dhcp, ok := dhcpLayer.(*layers.DHCPv4)
+		if !ok || dhcp.Operation != layers.DHCPOpRequest {
+			continue
+		}
+		mac := dhcp.ClientHWAddr.String()
+		if _, seen := result[mac]; seen {
+			continue
+		}
+		for _, opt := range dhcp.Options {
+			if opt.Type == layers.DHCPOptParamsRequest && len(opt.Data) > 0 {
+				parts := make([]string, len(opt.Data))
+				for i, b := range opt.Data {
+					parts[i] = strconv.Itoa(int(b))
+				}
+				result[mac] = strings.Join(parts, ",")
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+// PatchDHCPLog reads the Zeek dhcp.log TSV, fills in the param_req_list
+// column for any row whose MAC address appears in fingerprints, and writes
+// the file back in place.
+func PatchDHCPLog(logPath string, fingerprints map[string]string) error {
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read dhcp log: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	macIdx, paramIdx := -1, -1
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#fields\t") {
+			fields := strings.Split(line, "\t")[1:] // drop "#fields" prefix so indices match data columns
+			for i, f := range fields {
+				switch f {
+				case "mac":
+					macIdx = i
+				case "param_req_list":
+					paramIdx = i
+				}
+			}
+			break
+		}
+	}
+	if macIdx < 0 || paramIdx < 0 {
+		return nil
+	}
+
+	changed := false
+	for i, line := range lines {
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		cols := strings.Split(line, "\t")
+		if macIdx >= len(cols) || paramIdx >= len(cols) {
+			continue
+		}
+		if fp, ok := fingerprints[cols[macIdx]]; ok && cols[paramIdx] == "-" {
+			cols[paramIdx] = fp
+			lines[i] = strings.Join(cols, "\t")
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return os.WriteFile(logPath, []byte(strings.Join(lines, "\n")), 0644)
+}

--- a/internal/processor/common/dhcp_enrichment_test.go
+++ b/internal/processor/common/dhcp_enrichment_test.go
@@ -1,0 +1,103 @@
+package types
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const sampleDHCPLog = "#separator \\x09\n" +
+	"#set_separator\t,\n" +
+	"#empty_field\t(empty)\n" +
+	"#unset_field\t-\n" +
+	"#path\tdhcp\n" +
+	"#fields\tts\tuids\tclient_addr\tserver_addr\tmac\thost_name\tparam_req_list\tlease_time\n" +
+	"#types\ttime\tset[string]\taddr\taddr\tstring\tstring\tstring\tinterval\n" +
+	"1746000000.0\tCabc123\t192.168.1.10\t192.168.1.1\taa:bb:cc:dd:ee:ff\tmylaptop\t-\t86400.0\n" +
+	"1746000010.0\tCdef456\t192.168.1.20\t192.168.1.1\t11:22:33:44:55:66\tphone\t-\t86400.0\n"
+
+func TestPatchDHCPLog_FillsFingerprints(t *testing.T) {
+	f, err := os.CreateTemp("", "dhcp-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(sampleDHCPLog)
+	f.Close()
+
+	fingerprints := map[string]string{
+		"aa:bb:cc:dd:ee:ff": "1,3,6,15,119,252",
+		"11:22:33:44:55:66": "1,3,6,15,28,43",
+	}
+
+	if err := PatchDHCPLog(f.Name(), fingerprints); err != nil {
+		t.Fatalf("PatchDHCPLog error: %v", err)
+	}
+
+	content, _ := os.ReadFile(f.Name())
+	if !strings.Contains(string(content), "1,3,6,15,119,252") {
+		t.Error("expected first fingerprint in patched log")
+	}
+	if !strings.Contains(string(content), "1,3,6,15,28,43") {
+		t.Error("expected second fingerprint in patched log")
+	}
+}
+
+func TestPatchDHCPLog_Idempotent(t *testing.T) {
+	f, err := os.CreateTemp("", "dhcp-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	content := sampleDHCPLog
+	content = strings.Replace(content,
+		"aa:bb:cc:dd:ee:ff\tmylaptop\t-\t",
+		"aa:bb:cc:dd:ee:ff\tmylaptop\t1,3,6,15\t", 1)
+	f.WriteString(content)
+	f.Close()
+
+	fingerprints := map[string]string{
+		"aa:bb:cc:dd:ee:ff": "9,9,9,9",
+	}
+	if err := PatchDHCPLog(f.Name(), fingerprints); err != nil {
+		t.Fatalf("PatchDHCPLog error: %v", err)
+	}
+
+	out, _ := os.ReadFile(f.Name())
+	if strings.Contains(string(out), "9,9,9,9") {
+		t.Error("should not overwrite an already-set param_req_list value")
+	}
+}
+
+func TestPatchDHCPLog_MissingFile(t *testing.T) {
+	err := PatchDHCPLog("/nonexistent/dhcp.log", map[string]string{"aa:bb:cc:dd:ee:ff": "1,3,6"})
+	if err != nil {
+		t.Errorf("expected nil for missing file, got: %v", err)
+	}
+}
+
+func TestPatchDHCPLog_NoParamReqListColumn(t *testing.T) {
+	f, err := os.CreateTemp("", "dhcp-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString("#fields\tts\tmac\tlease_time\n1746000000.0\taa:bb:cc:dd:ee:ff\t86400.0\n")
+	f.Close()
+
+	err = PatchDHCPLog(f.Name(), map[string]string{"aa:bb:cc:dd:ee:ff": "1,3,6"})
+	if err != nil {
+		t.Errorf("expected nil when column absent, got: %v", err)
+	}
+}
+
+func TestExtractDHCPFingerprints_MissingFile(t *testing.T) {
+	result, err := ExtractDHCPFingerprints("/nonexistent/capture.pcapng")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+	if result != nil {
+		t.Error("expected nil result for missing file")
+	}
+}

--- a/internal/processor/linux/processor.go
+++ b/internal/processor/linux/processor.go
@@ -92,6 +92,20 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 	baseArgs := []string{"-r", pcapPath, fmt.Sprintf("Log::default_logdir=%s", runDir), "-C"}
 	zeekArgs := types.PrepareZeekArgsWithSampling(pcapPath, runDir, samplingPercentage, baseArgs)
 
+	// Add DHCP fingerprint script if available so param_req_list appears in dhcp.log
+	fingerprintScriptPaths := []string{
+		"zeek-scripts/dhcp-fingerprint.zeek",
+		filepath.Join("..", "..", "zeek-scripts", "dhcp-fingerprint.zeek"),
+		filepath.Join(filepath.Dir(pcapPath), "..", "..", "zeek-scripts", "dhcp-fingerprint.zeek"),
+	}
+	for _, path := range fingerprintScriptPaths {
+		if _, err := os.Stat(path); err == nil {
+			zeekArgs = append(zeekArgs, path)
+			log.Printf("[processor] Added DHCP fingerprint script from %s", path)
+			break
+		}
+	}
+
 	log.Printf("[processor] Running Zeek: %s %v", p.zeekPath, zeekArgs)
 	cmd := p.cmdRunner.Command(p.zeekPath, zeekArgs...)
 	cmdStdout, ok := cmd.(*realCmd)
@@ -104,6 +118,11 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 		return types.ProcessedData{}, fmt.Errorf("zeek failed: %w", err)
 	}
 	log.Printf("[processor] Zeek execution completed successfully.")
+
+	dhcpLogPath := filepath.Join(runDir, "dhcp.log")
+	if err := types.EnrichDHCPLog(pcapPath, dhcpLogPath); err != nil {
+		log.Printf("[processor] Warning: DHCP enrichment failed: %v", err)
+	}
 
 	paths, err := types.RenameZeekLogsToXLSX(p.fs, runDir, zeekLogFiles)
 	if err != nil {

--- a/internal/processor/windows/dhcp_enrichment.go
+++ b/internal/processor/windows/dhcp_enrichment.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package windows
+
+import types "EnigmaNetz/Enigma-Go-Sensor/internal/processor/common"
+
+func enrichDHCPLog(pcapPath, dhcpLogPath string) error {
+	return types.EnrichDHCPLog(pcapPath, dhcpLogPath)
+}

--- a/internal/processor/windows/dhcp_enrichment_test.go
+++ b/internal/processor/windows/dhcp_enrichment_test.go
@@ -1,0 +1,109 @@
+//go:build windows
+
+package windows
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	types "EnigmaNetz/Enigma-Go-Sensor/internal/processor/common"
+)
+
+const sampleDHCPLog = "#separator \\x09\n" +
+	"#set_separator\t,\n" +
+	"#empty_field\t(empty)\n" +
+	"#unset_field\t-\n" +
+	"#path\tdhcp\n" +
+	"#fields\tts\tuids\tclient_addr\tserver_addr\tmac\thost_name\tparam_req_list\tlease_time\n" +
+	"#types\ttime\tset[string]\taddr\taddr\tstring\tstring\tstring\tinterval\n" +
+	"1746000000.0\tCabc123\t192.168.1.10\t192.168.1.1\taa:bb:cc:dd:ee:ff\tmylaptop\t-\t86400.0\n" +
+	"1746000010.0\tCdef456\t192.168.1.20\t192.168.1.1\t11:22:33:44:55:66\tphone\t-\t86400.0\n"
+
+func TestPatchDHCPLog_FillsFingerprints(t *testing.T) {
+	f, err := os.CreateTemp("", "dhcp-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(sampleDHCPLog)
+	f.Close()
+
+	fingerprints := map[string]string{
+		"aa:bb:cc:dd:ee:ff": "1,3,6,15,119,252",
+		"11:22:33:44:55:66": "1,3,6,15,28,43",
+	}
+
+	if err := types.PatchDHCPLog(f.Name(), fingerprints); err != nil {
+		t.Fatalf("PatchDHCPLog error: %v", err)
+	}
+
+	content, _ := os.ReadFile(f.Name())
+	if !strings.Contains(string(content), "1,3,6,15,119,252") {
+		t.Error("expected first fingerprint in patched log")
+	}
+	if !strings.Contains(string(content), "1,3,6,15,28,43") {
+		t.Error("expected second fingerprint in patched log")
+	}
+}
+
+func TestPatchDHCPLog_Idempotent(t *testing.T) {
+	f, err := os.CreateTemp("", "dhcp-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	// Log already has a value set — should not be overwritten
+	content := sampleDHCPLog
+	content = strings.Replace(content,
+		"aa:bb:cc:dd:ee:ff\tmylaptop\t-\t",
+		"aa:bb:cc:dd:ee:ff\tmylaptop\t1,3,6,15\t", 1)
+	f.WriteString(content)
+	f.Close()
+
+	fingerprints := map[string]string{
+		"aa:bb:cc:dd:ee:ff": "9,9,9,9",
+	}
+	if err := types.PatchDHCPLog(f.Name(), fingerprints); err != nil {
+		t.Fatalf("PatchDHCPLog error: %v", err)
+	}
+
+	out, _ := os.ReadFile(f.Name())
+	if strings.Contains(string(out), "9,9,9,9") {
+		t.Error("should not overwrite an already-set param_req_list value")
+	}
+}
+
+func TestPatchDHCPLog_MissingFile(t *testing.T) {
+	err := types.PatchDHCPLog("/nonexistent/dhcp.log", map[string]string{"aa:bb:cc:dd:ee:ff": "1,3,6"})
+	if err != nil {
+		t.Errorf("expected nil for missing file, got: %v", err)
+	}
+}
+
+func TestPatchDHCPLog_NoParamReqListColumn(t *testing.T) {
+	f, err := os.CreateTemp("", "dhcp-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	// Log without param_req_list column
+	f.WriteString("#fields\tts\tmac\tlease_time\n1746000000.0\taa:bb:cc:dd:ee:ff\t86400.0\n")
+	f.Close()
+
+	err = types.PatchDHCPLog(f.Name(), map[string]string{"aa:bb:cc:dd:ee:ff": "1,3,6"})
+	if err != nil {
+		t.Errorf("expected nil when column absent, got: %v", err)
+	}
+}
+
+func TestExtractDHCPFingerprints_MissingFile(t *testing.T) {
+	result, err := types.ExtractDHCPFingerprints("/nonexistent/capture.pcapng")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+	if result != nil {
+		t.Error("expected nil result for missing file")
+	}
+}

--- a/internal/processor/windows/processor.go
+++ b/internal/processor/windows/processor.go
@@ -94,6 +94,15 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 	}
 	log.Printf("[processor] Zeek execution completed successfully.")
 
+	// Enrich dhcp.log with DHCP option 55 (parameter request list).
+	// The Zeek build bundled in zeek-runtime-win64.zip does not expose
+	// DHCP::Options$param_req_list at script level, so we extract it here
+	// directly from the pcap using gopacket.
+	dhcpLogPath := filepath.Join(runDir, "dhcp.log")
+	if err := enrichDHCPLog(pcapPath, dhcpLogPath); err != nil {
+		log.Printf("[processor] Warning: DHCP enrichment failed: %v", err)
+	}
+
 	logFiles := []string{"conn.log", "dns.log", "dhcp.log", "ja3_ja4.log", "ja4s.log"}
 	paths, err := types.RenameZeekLogsToXLSX(p.fs, runDir, logFiles)
 	if err != nil {

--- a/internal/sensor/sensor.go
+++ b/internal/sensor/sensor.go
@@ -172,6 +172,42 @@ func ensureZeekWindows() error {
 		log.Printf("[sensor] Warning: Sampling script not found at %s", samplingScriptSrc)
 	}
 
+	// Copy DHCP fingerprint script to the custom-scripts directory if it exists
+	fingerprintScriptSrc := "zeek-scripts/dhcp-fingerprint.zeek"
+	fingerprintScriptDst := filepath.Join(zeekDir, "zeek-runtime-win64", "share", "zeek", "site", "custom-scripts", "dhcp-fingerprint.zeek")
+
+	if _, err := os.Stat(fingerprintScriptSrc); err == nil {
+		srcFile, err := os.Open(fingerprintScriptSrc)
+		if err != nil {
+			log.Printf("[sensor] Warning: Failed to open DHCP fingerprint script source: %v", err)
+		} else {
+			defer srcFile.Close()
+
+			if err := os.MkdirAll(filepath.Dir(fingerprintScriptDst), 0755); err != nil {
+				log.Printf("[sensor] Warning: Failed to create DHCP fingerprint script destination directory: %v", err)
+			} else {
+				dstFile, err := os.Create(fingerprintScriptDst)
+				if err != nil {
+					log.Printf("[sensor] Warning: Failed to create DHCP fingerprint script destination: %v", err)
+				} else {
+					defer dstFile.Close()
+					if _, err := io.Copy(dstFile, srcFile); err != nil {
+						log.Printf("[sensor] Warning: Failed to copy DHCP fingerprint script: %v", err)
+					} else {
+						log.Printf("[sensor] Successfully copied DHCP fingerprint script to Windows Zeek runtime")
+
+						mainZeekPath := filepath.Join(zeekDir, "zeek-runtime-win64", "share", "zeek", "site", "custom-scripts", "main.zeek")
+						if err := addFingerprintScriptToMainZeek(mainZeekPath); err != nil {
+							log.Printf("[sensor] Warning: Failed to update main.zeek for DHCP fingerprint: %v", err)
+						}
+					}
+				}
+			}
+		}
+	} else {
+		log.Printf("[sensor] Warning: DHCP fingerprint script not found at %s", fingerprintScriptSrc)
+	}
+
 	return nil
 }
 
@@ -201,6 +237,31 @@ func addSamplingScriptToMainZeek(mainZeekPath string) error {
 	}
 
 	log.Printf("[sensor] Added sampling script load directive to main.zeek")
+	return nil
+}
+
+// addFingerprintScriptToMainZeek adds the DHCP fingerprint script load directive to main.zeek if not already present
+func addFingerprintScriptToMainZeek(mainZeekPath string) error {
+	content, err := os.ReadFile(mainZeekPath)
+	if err != nil {
+		return fmt.Errorf("failed to read main.zeek: %w", err)
+	}
+
+	contentStr := string(content)
+	fingerprintLoadDirective := "@load ./dhcp-fingerprint.zeek"
+
+	if strings.Contains(contentStr, fingerprintLoadDirective) {
+		log.Printf("[sensor] DHCP fingerprint script already loaded in main.zeek")
+		return nil
+	}
+
+	updatedContent := contentStr + "\n" + fingerprintLoadDirective + "\n"
+
+	if err := os.WriteFile(mainZeekPath, []byte(updatedContent), 0644); err != nil {
+		return fmt.Errorf("failed to write updated main.zeek: %w", err)
+	}
+
+	log.Printf("[sensor] Added DHCP fingerprint script load directive to main.zeek")
 	return nil
 }
 

--- a/internal/sensor/sensor_test.go
+++ b/internal/sensor/sensor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -277,6 +278,52 @@ func TestRunSensor_ConcurrentWorkers(t *testing.T) {
 	}
 	t.Logf("Concurrent workers processed %d PCAPs", finalProcCalls)
 	t.Log("TestRunSensor_ConcurrentWorkers end reached")
+}
+
+func TestAddFingerprintScriptToMainZeek_AddsDirective(t *testing.T) {
+	f, err := os.CreateTemp("", "main-*.zeek")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString("@load base/protocols/dhcp\n")
+	f.Close()
+
+	if err := addFingerprintScriptToMainZeek(f.Name()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, _ := os.ReadFile(f.Name())
+	if !strings.Contains(string(content), "@load ./dhcp-fingerprint.zeek") {
+		t.Errorf("expected directive in main.zeek, got:\n%s", content)
+	}
+}
+
+func TestAddFingerprintScriptToMainZeek_Idempotent(t *testing.T) {
+	f, err := os.CreateTemp("", "main-*.zeek")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString("@load base/protocols/dhcp\n@load ./dhcp-fingerprint.zeek\n")
+	f.Close()
+
+	if err := addFingerprintScriptToMainZeek(f.Name()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, _ := os.ReadFile(f.Name())
+	count := strings.Count(string(content), "@load ./dhcp-fingerprint.zeek")
+	if count != 1 {
+		t.Errorf("expected directive exactly once, found %d times", count)
+	}
+}
+
+func TestAddFingerprintScriptToMainZeek_MissingFile(t *testing.T) {
+	err := addFingerprintScriptToMainZeek("/nonexistent/path/main.zeek")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
 }
 
 func TestValidateZipPath_RejectsPathTraversal(t *testing.T) {

--- a/zeek-scripts/dhcp-fingerprint.zeek
+++ b/zeek-scripts/dhcp-fingerprint.zeek
@@ -1,0 +1,10 @@
+@load base/protocols/dhcp
+
+module DHCP;
+
+# Adds param_req_list column to dhcp.log. Values are populated by the Go
+# processor via gopacket after Zeek runs, because this Zeek build does not
+# expose DHCP::Options$param_req_list at script level.
+redef record Info += {
+    param_req_list: string &optional &log;
+};


### PR DESCRIPTION
 ## Summary

  - Adds `zeek-scripts/dhcp-fingerprint.zeek` which extends `DHCP::Info` with a `param_req_list: string &optional &log`
  field, making the column appear in `dhcp.log`
  - **Windows**: sensor startup copies the script and injects `@load ./dhcp-fingerprint.zeek` into `main.zeek` (idempotent)
  - **Linux**: script is passed directly as a Zeek CLI arg alongside the pcap
  - After Zeek runs, `EnrichDHCPLog` (in `processor/common`) reads DHCP option 55 from the capture file via gopacket and
  patches any `-` values in `dhcp.log` before rename/upload — supports both pcapng (Windows pktmon) and regular pcap (Linux
  tcpdump)
  - Non-fatal: any enrichment failure is logged as a warning and processing continues

  **Why not pure Zeek scripting?** Neither the bundled Windows Zeek (8.0.0-dev.72) nor system Linux Zeek (8.0.5) expose
  `DHCP::Options$param_req_list` at script level — confirmed by grepping both Zeek installations. The hybrid approach (Zeek
  defines the column, Go populates it) works on both platforms.

  **Tested on:**
  - Windows 10 — gopacket extracted 3 fingerprints from a 15,275-packet capture, upload succeeded
  - WSL/Linux — `dhcp-fingerprint.zeek` loads cleanly against Zeek 8.0.5, column present in `#fields`

  ## Follow-up

  Subscriber wiring is a separate ticket: `dhcp-parser.ts` needs to read `param_req_list` from the TSV row and pass it to
  Fingerbank as `dhcp_fingerprint` instead of `undefined`.

  ## Test plan

  - [ ] `GOOS=linux GOARCH=amd64 go test ./internal/processor/...` passes
  - [ ] `GOOS=windows GOARCH=amd64 go test ./internal/processor/...` passes
  - [ ] Apply `build:windows` label to trigger Windows artifact build
  - [ ] Confirm `param_req_list` populated in staging dhcp records after a capture with DHCP traffic

Ref B1CF-1643