### PR TITLE
Optional private-CA TLS for the sensor (ca_cert_file)

### DIFF
--- a/cmd/enigma-sensor/main.go
+++ b/cmd/enigma-sensor/main.go
@@ -145,7 +145,7 @@ func main() {
 		if server == "" || apiKey == "" {
 			log.Printf("enigma_api.server and enigma_api.api_key must be set to upload logs; skipping upload.")
 		} else {
-			u, err := api.NewLogUploader(server, apiKey, cfg.NetworkID, cfg.Capture.Interface, cfg.EnigmaAPI.MaxPayloadSizeMB, cfg.Buffering.Dir, cfg.Buffering.MaxAgeHours)
+			u, err := api.NewLogUploader(server, apiKey, cfg.NetworkID, cfg.Capture.Interface, cfg.EnigmaAPI.MaxPayloadSizeMB, cfg.Buffering.Dir, cfg.Buffering.MaxAgeHours, cfg.EnigmaAPI.CACertFile)
 			if err != nil {
 				log.Printf("Failed to initialize LogUploader: %v", err)
 			} else {

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 		Server string `json:"server"`
 		// APIKey is the Enigma API key
 		APIKey string `json:"api_key"`
+		// CACertFile is an optional PEM CA certificate file for gRPC TLS
+		CACertFile string `json:"ca_cert_file"`
 		// Upload is whether to upload captured data to the Enigma API
 		Upload bool `json:"upload"`
 		// MaxPayloadSizeMB is the maximum size of payload before chunking (default: 25MB)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -69,15 +70,27 @@ type grpcClientImpl struct {
 }
 
 // NewLogUploader creates a new log uploader instance
-func NewLogUploader(serverAddr string, apiKey string, networkID string, captureInterface string, maxPayloadSizeMB int64, bufferDir string, bufferMaxAgeHours int) (*LogUploader, error) {
+func NewLogUploader(serverAddr string, apiKey string, networkID string, captureInterface string, maxPayloadSizeMB int64, bufferDir string, bufferMaxAgeHours int, caCertFile string) (*LogUploader, error) {
 	var opts []grpc.DialOption
 
-	// Always use SSL credentials with system trust store
 	host := serverAddr
 	if idx := strings.LastIndex(serverAddr, ":"); idx >= 0 {
 		host = serverAddr[:idx]
 	}
-	creds := credentials.NewClientTLSFromCert(nil, host)
+	var creds credentials.TransportCredentials
+	if caCertFile == "" {
+		creds = credentials.NewClientTLSFromCert(nil, host)
+	} else {
+		pem, err := os.ReadFile(caCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate file %s: %w", caCertFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("failed to parse CA certificate file %s", caCertFile)
+		}
+		creds = credentials.NewClientTLSFromCert(pool, host)
+	}
 	opts = append(opts, grpc.WithTransportCredentials(creds))
 
 	// Add keepalive options

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -4,17 +4,23 @@ import (
 	"bytes"
 	"compress/zlib"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-
-	"errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,6 +68,83 @@ func (m *mockPublishClient) uploadExcelMethod(ctx context.Context, data []byte, 
 	resp := m.uploadResponses[m.currentCall]
 	m.currentCall++
 	return resp.status, resp.statusCode, resp.message, resp.err
+}
+
+func TestNewLogUploaderCACertFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		certFile   func(t *testing.T) string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "empty cert file uses system trust store",
+			certFile: func(t *testing.T) string {
+				return ""
+			},
+		},
+		{
+			name: "valid cert file succeeds",
+			certFile: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "ca.pem")
+				require.NoError(t, os.WriteFile(path, generateTestCACertPEM(t), 0644))
+				return path
+			},
+		},
+		{
+			name: "missing cert file errors",
+			certFile: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing.pem")
+			},
+			wantErr:    true,
+			errContain: "failed to read CA certificate file",
+		},
+		{
+			name: "invalid cert file errors",
+			certFile: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "ca.pem")
+				require.NoError(t, os.WriteFile(path, []byte("not a PEM certificate"), 0644))
+				return path
+			},
+			wantErr:    true,
+			errContain: "failed to parse CA certificate file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uploader, err := NewLogUploader("api.example.test:443", "test-key", "Test-Network-01", "any", 25, t.TempDir(), 24, tt.certFile(t))
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContain)
+				assert.Nil(t, uploader)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, uploader)
+		})
+	}
+}
+
+func generateTestCACertPEM(t *testing.T) []byte {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 }
 
 // TestLogUploader_UploadLogs verifies the LogUploader's UploadLogs method for various scenarios:

--- a/internal/sensor/sensor_test.go
+++ b/internal/sensor/sensor_test.go
@@ -126,6 +126,7 @@ func minimalConfig(loop bool) *config.Config {
 		EnigmaAPI: struct {
 			Server           string `json:"server"`
 			APIKey           string `json:"api_key"`
+			CACertFile       string `json:"ca_cert_file"`
 			Upload           bool   `json:"upload"`
 			MaxPayloadSizeMB int64  `json:"max_payload_size_mb"`
 		}{},


### PR DESCRIPTION
Adds an optional `ca_cert_file` to the EnigmaAPI config. When set, the sensor loads the PEM and trusts that CA for its gRPC TLS connection to the Enigma API (for on-prem deployments behind a private CA). When unset, the TLS path is byte-identical to today (public-CA via the system roots), so there is no change to existing deployments.

Part of the on-prem Phase 0 series (sensor/pub/sub/ml); each ships as its own no-behavior-change PR introducing the integration seam a later phase will swap.


Ref B1CF-1747

