### PR TITLE
ci: Node 24 actions upgrade (B1CF-1787)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keeps the github-actions ecosystem current in the steady state. Scans
+# .github/workflows/*.yml (and any in-repo composite actions), opening grouped
+# PRs when new versions land.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/build-artifacts-reusable.yml
+++ b/.github/workflows/build-artifacts-reusable.yml
@@ -40,10 +40,10 @@ jobs:
     if: inputs.build_windows
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.x'
           cache: true
@@ -70,7 +70,7 @@ jobs:
         shell: powershell
 
       - name: Upload Windows Installer Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: enigma-sensor-windows-${{ inputs.artifact_prefix }}
           path: installer/windows/Output/enigma-sensor-windows-*.exe
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: inputs.upload_to_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: installer/windows/Output/enigma-sensor-windows-*.exe
         env:
@@ -90,10 +90,10 @@ jobs:
     if: inputs.build_linux
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.x'
           cache: true
@@ -129,7 +129,7 @@ jobs:
           cd ..
 
       - name: Upload Linux Package Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: enigma-sensor-linux-${{ inputs.artifact_prefix }}
           path: bin/enigma-sensor-linux-*.deb
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: inputs.upload_to_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             enigma-sensor-*-linux-release.zip
@@ -151,10 +151,10 @@ jobs:
     if: inputs.build_macos
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.x'
           cache: true
@@ -170,7 +170,7 @@ jobs:
           tar -czf enigma-sensor-macos-${{ inputs.artifact_prefix }}.tar.gz enigma-sensor-darwin-*
 
       - name: Upload macOS Binary Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: enigma-sensor-macos-${{ inputs.artifact_prefix }}
           path: bin/enigma-sensor-macos-*.tar.gz
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: inputs.upload_to_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: bin/enigma-sensor-darwin-${{ inputs.artifact_prefix }}
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/enigmanetz/enigma-sensor
           tags: |
@@ -39,7 +39,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -18,10 +18,10 @@ jobs:
         go-version: ['1.24.x']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
         cache: true


### PR DESCRIPTION
Part of epic **B1CF-1776** — GitHub Actions: Node 24 upgrade + consolidation. Ticket **B1CF-1787** (R9 — Enigma-Sensor). Go/Docker only — **no shared dependency**.

One-pass Node 24 runner migration:

- Bumps: `checkout` v4→v5, `setup-go` v4→v6, `upload-artifact` v4→v5, `softprops/action-gh-release` v2→v3, `docker/setup-buildx-action` v3→v4, `docker/login-action` v3→v4, `docker/metadata-action` v5→v6, `docker/build-push-action` v6→v7.
- Add `.github/dependabot.yml` (weekly grouped `github-actions` updates).

(No `gcp-auth` / `notify-prod-merge` usage — this repo shares nothing with Enigma-Release, so it can merge independently of the F2 PR.)

Validated with `actionlint` (exit 0); no remaining Node-20 action pins.

Opened as a **draft** for consistency with the rest of the R-series rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H39481czqGG5Q9Tsn1d2XD)_