### PR TITLE
B1CF-1830 Subnet/CIDR Exclusion Filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ type Capturer interface {
 }
 
 type Processor interface {
-    ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error)
+    ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error)
 }
 
 type Uploader interface {

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ docker run -d \
 | `SENSOR_CAPTURE_WINDOW_SECONDS` | No | `60` | Duration of each capture window in seconds |
 | `SENSOR_CAPTURE_INTERFACE` | No | `any` | Network interface to capture from |
 | `SENSOR_ZEEK_SAMPLING_PERCENTAGE` | No | `100` | Percentage of traffic to process (0 to 100) |
+| `SENSOR_ZEEK_EXCLUDED_SUBNETS` | No | | Comma-delimited CIDRs (e.g. `10.0.0.0/8,172.20.10.0/24`) whose flows/records are dropped and never uploaded. Empty = disabled. |
 | `SENSOR_LOGGING_LEVEL` | No | `info` | Log level (debug, info, warn, error) |
 
 Any config field in `config.json` can be overridden via environment variables using the pattern `SENSOR_<SECTION>_<FIELD>`, where section and field names come from the JSON keys, uppercased. For example, `logging.max_size_mb` becomes `SENSOR_LOGGING_MAX_SIZE_MB`. See `config.example.json` for all available fields.

--- a/config.example.json
+++ b/config.example.json
@@ -24,7 +24,8 @@
     "max_age_hours": 2
   },
   "zeek": {
-    "sampling_percentage": 100
+    "sampling_percentage": 100,
+    "excluded_subnets": ""
   },
   "pcap_ingest": {
     "enabled": false,

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"strings"
@@ -71,6 +72,13 @@ type Config struct {
 		Path string `json:"path"`
 		// SamplingPercentage is the percentage of traffic to process (0-100)
 		SamplingPercentage float64 `json:"sampling_percentage"`
+		// ExcludedSubnets is a comma-delimited list of CIDRs (e.g.
+		// "10.0.0.0/8,172.20.10.0/24"). Any flow/record whose source or
+		// destination IP falls inside one of these subnets is dropped from the
+		// produced logs and never uploaded. Stored as a single string (not an
+		// array) so it flows through the reflection-based SENSOR_ env overrides
+		// (SENSOR_ZEEK_EXCLUDED_SUBNETS). Empty = feature off.
+		ExcludedSubnets string `json:"excluded_subnets"`
 	} `json:"zeek"`
 
 	// PcapIngest configuration for offline PCAP file processing
@@ -84,6 +92,24 @@ type Config struct {
 		// FileStableSeconds is how long a file's size must be unchanged before processing (default: 5, min: 1, max: 60)
 		FileStableSeconds int `json:"file_stable_seconds"`
 	} `json:"pcap_ingest"`
+}
+
+// splitCSV splits a comma-delimited string into trimmed, non-empty entries.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// ExcludedSubnetList returns the configured excluded subnet CIDRs as a trimmed,
+// non-empty slice. Returns nil when the feature is off. Entries are validated by
+// ValidateAndSetDefaults at load time.
+func (c *Config) ExcludedSubnetList() []string {
+	return splitCSV(c.Zeek.ExcludedSubnets)
 }
 
 // validateNetworkID validates the network_id format
@@ -179,6 +205,13 @@ func (config *Config) ValidateAndSetDefaults() error {
 	// Zeek path can be empty by default
 	if config.Zeek.SamplingPercentage == 0 {
 		config.Zeek.SamplingPercentage = 100 // Default to 100% (process all traffic)
+	}
+	// Validate excluded_subnets: empty = feature off. Every comma-separated
+	// entry must be a valid CIDR; reject malformed lists with a clear error.
+	for _, entry := range splitCSV(config.Zeek.ExcludedSubnets) {
+		if _, _, err := net.ParseCIDR(entry); err != nil {
+			return fmt.Errorf("zeek.excluded_subnets: invalid CIDR %q (expected e.g. 10.0.0.0/8): %w", entry, err)
+		}
 	}
 	// Defaults for buffering
 	if config.Buffering.Dir == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,68 @@ import (
 	"testing"
 )
 
+func TestValidateExcludedSubnets(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantError bool
+		wantList  []string
+	}{
+		{"empty is feature off", "", false, nil},
+		{"single valid cidr", "10.0.0.0/8", false, []string{"10.0.0.0/8"}},
+		{"multiple valid cidrs with spaces", "10.0.0.0/8, 172.20.10.0/24", false, []string{"10.0.0.0/8", "172.20.10.0/24"}},
+		{"ipv6 cidr", "fd00::/8", false, []string{"fd00::/8"}},
+		{"trailing comma tolerated", "10.0.0.0/8,", false, []string{"10.0.0.0/8"}},
+		{"missing mask rejected", "10.0.0.0", true, nil},
+		{"garbage rejected", "10.0.0.0/8,not-a-cidr", true, nil},
+		{"bad mask rejected", "10.0.0.0/99", true, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newBaseConfig()
+			cfg.Zeek.ExcludedSubnets = tt.value
+			err := cfg.ValidateAndSetDefaults()
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.value, err)
+			}
+			got := cfg.ExcludedSubnetList()
+			if len(got) != len(tt.wantList) {
+				t.Fatalf("ExcludedSubnetList() = %v, want %v", got, tt.wantList)
+			}
+			for i := range got {
+				if got[i] != tt.wantList[i] {
+					t.Errorf("entry %d = %q, want %q", i, got[i], tt.wantList[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExcludedSubnetsEnvOverride(t *testing.T) {
+	cfg := newBaseConfig()
+	t.Setenv("SENSOR_ZEEK_EXCLUDED_SUBNETS", "10.0.0.0/8,192.168.0.0/16")
+
+	if err := ApplyEnvOverrides(&cfg); err != nil {
+		t.Fatalf("ApplyEnvOverrides: %v", err)
+	}
+	if cfg.Zeek.ExcludedSubnets != "10.0.0.0/8,192.168.0.0/16" {
+		t.Fatalf("env override not applied, got %q", cfg.Zeek.ExcludedSubnets)
+	}
+	if err := cfg.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("validation after override: %v", err)
+	}
+	if list := cfg.ExcludedSubnetList(); len(list) != 2 {
+		t.Errorf("expected 2 excluded subnets after override, got %v", list)
+	}
+}
+
 func TestValidateInterfaceName(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/pcapingest/watcher.go
+++ b/internal/pcapingest/watcher.go
@@ -17,7 +17,7 @@ import (
 
 // Processor processes a PCAP file and returns structured log data.
 type Processor interface {
-	ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error)
+	ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error)
 }
 
 // Uploader uploads processed log files to the API.
@@ -31,6 +31,7 @@ type WatcherConfig struct {
 	PollInterval      time.Duration
 	FileStableSeconds int
 	SamplingPct       float64
+	ExcludedSubnets   []string
 }
 
 // Watcher polls a directory for incoming PCAP files and feeds them through
@@ -42,6 +43,7 @@ type Watcher struct {
 	processor         Processor
 	uploader          Uploader
 	samplingPct       float64
+	excludedSubnets   []string
 }
 
 // NewWatcher creates a new PCAP directory watcher.
@@ -53,6 +55,7 @@ func NewWatcher(cfg WatcherConfig, proc Processor, uploader Uploader) *Watcher {
 		processor:         proc,
 		uploader:          uploader,
 		samplingPct:       cfg.SamplingPct,
+		excludedSubnets:   cfg.ExcludedSubnets,
 	}
 }
 
@@ -171,7 +174,10 @@ func (w *Watcher) processFile(ctx context.Context, srcPath, processingDir, proce
 
 	log.Printf("[pcap-ingest] Processing %s", fileName)
 
-	result, err := w.processor.ProcessPCAP(procPath, w.samplingPct)
+	result, err := w.processor.ProcessPCAP(procPath, types.ProcessOptions{
+		SamplingPercentage: w.samplingPct,
+		ExcludedSubnets:    w.excludedSubnets,
+	})
 	if err != nil {
 		log.Printf("[pcap-ingest] Processing failed for %s: %v", fileName, err)
 		// Move to failed

--- a/internal/pcapingest/watcher_test.go
+++ b/internal/pcapingest/watcher_test.go
@@ -18,7 +18,7 @@ type mockProcessor struct {
 	result types.ProcessedData
 }
 
-func (m *mockProcessor) ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error) {
+func (m *mockProcessor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error) {
 	m.calls++
 	if m.fail {
 		return types.ProcessedData{}, errors.New("process failed")

--- a/internal/processor/common/processor.go
+++ b/internal/processor/common/processor.go
@@ -10,8 +10,25 @@ import (
 // Processor defines the interface for platform-agnostic PCAP processing using Zeek.
 // Implementations should process the given PCAP file and return XLSX file paths for both con.log and dns.log.
 type Processor interface {
-	ProcessPCAP(pcapPath string, samplingPercentage float64) (ProcessedData, error)
+	ProcessPCAP(pcapPath string, opts ProcessOptions) (ProcessedData, error)
 }
+
+// ProcessOptions carries the per-run knobs for ProcessPCAP. Bundling them keeps
+// the ProcessPCAP signature stable as new knobs are added.
+type ProcessOptions struct {
+	// SamplingPercentage is the percentage of traffic to process (0-100).
+	SamplingPercentage float64
+	// ExcludedSubnets is the list of CIDRs whose flows/records must be dropped
+	// from the produced logs before upload. Empty = no filtering.
+	ExcludedSubnets []string
+}
+
+// ZeekLogFiles is the single source of truth for the Zeek logs the sensor
+// uploads. Both FilterExcludedSubnets and RenameZeekLogsToXLSX key off this
+// list so "what we filter" and "what we upload" can never drift apart — adding
+// a sixth uploaded log here automatically brings it under subnet filtering on
+// every platform.
+var ZeekLogFiles = []string{"conn.log", "dns.log", "dhcp.log", "ja3_ja4.log", "ja4s.log"}
 
 // ProcessedData represents the output of PCAP processing.
 type ProcessedData struct {

--- a/internal/processor/common/subnet_filter.go
+++ b/internal/processor/common/subnet_filter.go
@@ -1,0 +1,227 @@
+package types
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// addressFields is the set of Zeek log column names that hold a single IP
+// address we filter on. Located by name via the log's #fields header (never by
+// hardcoded index) so the same code path covers every uploaded log:
+//   - conn, dns, ja3_ja4, ja4s: id.orig_h, id.resp_h
+//   - dhcp: client_addr, server_addr, requested_addr, assigned_addr
+//
+// A column name only appears here where it is genuinely an address, so keying
+// off the name alone is safe across all five logs.
+var addressFields = map[string]bool{
+	"id.orig_h":      true,
+	"id.resp_h":      true,
+	"client_addr":    true,
+	"server_addr":    true,
+	"requested_addr": true,
+	"assigned_addr":  true,
+}
+
+// addressSetFields names Zeek columns that hold a set/vector of values (joined
+// by the log's #set_separator) which may include IP addresses. dns.log "answers"
+// is the case that matters: a DNS reply resolving to an excluded-subnet IP would
+// otherwise leak that internal address even when the client/resolver are not in
+// an excluded subnet. Each element is checked individually; non-IP members
+// (CNAMEs, MX targets, TXT data, ...) are ignored.
+var addressSetFields = map[string]bool{
+	"answers": true,
+}
+
+// zeekUnsetMarkers are the placeholder tokens Zeek writes for an absent value.
+// They are not addresses and must be skipped, not parsed.
+var zeekUnsetMarkers = map[string]bool{
+	"-":       true,
+	"(empty)": true,
+}
+
+// FilterExcludedSubnets rewrites each of the given Zeek TSV logs in runDir in
+// place, dropping any data row that references an excluded-subnet address —
+// either a source/destination address column (see addressFields) or an IP in a
+// set-valued column such as dns.log "answers" (see addressSetFields). Header/
+// footer lines (#separator, #fields, #types, #open, #close, ...) are preserved
+// verbatim. Missing log files are a no-op (JA3/JA4 may be absent, e.g. on
+// Linux). An empty/whitespace CIDR list turns the feature off.
+//
+// Filtering is a "do not upload it" guarantee, so any read/parse/write failure
+// on a present log is returned as an error rather than swallowed — the caller
+// aborts the capture window rather than risk uploading unfiltered data.
+func FilterExcludedSubnets(runDir string, logFiles []string, excludedCIDRs []string) error {
+	nets := parseCIDRs(excludedCIDRs)
+	if len(nets) == 0 {
+		return nil
+	}
+	for _, name := range logFiles {
+		if err := filterLogFile(filepath.Join(runDir, name), nets); err != nil {
+			return fmt.Errorf("filter %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// parseCIDRs converts CIDR strings to *net.IPNet. Malformed entries are skipped
+// with a warning; config validation is the authoritative gate, this keeps the
+// filter robust when called directly (e.g. in tests).
+func parseCIDRs(cidrs []string) []*net.IPNet {
+	var nets []*net.IPNet
+	for _, c := range cidrs {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			log.Printf("[processor] Warning: skipping invalid excluded subnet %q: %v", c, err)
+			continue
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
+// filterLogFile drops excluded rows from a single Zeek TSV log, in place.
+func filterLogFile(logPath string, nets []*net.IPNet) error {
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+
+	sep := "\t"
+	setSep := ","
+	var addrIdx []int // single-IP columns
+	var setIdx []int  // set-of-values columns (e.g. dns answers)
+	for _, line := range lines {
+		if strings.HasPrefix(line, "#separator") {
+			sep = parseSeparator(line)
+			continue
+		}
+		if strings.HasPrefix(line, "#set_separator") {
+			// Delimited by the main separator, which is already known by now.
+			if parts := strings.Split(line, sep); len(parts) >= 2 && parts[1] != "" {
+				setSep = parts[1]
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "#fields") {
+			// Drop the "#fields" token so the remaining indices align with data columns.
+			fields := strings.Split(line, sep)[1:]
+			for i, f := range fields {
+				switch {
+				case addressFields[f]:
+					addrIdx = append(addrIdx, i)
+				case addressSetFields[f]:
+					setIdx = append(setIdx, i)
+				}
+			}
+			break
+		}
+	}
+	// No #fields header, or no address columns in this log: nothing to filter.
+	if len(addrIdx) == 0 && len(setIdx) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(lines))
+	dropped := 0
+	for _, line := range lines {
+		// Preserve every header/footer line and the trailing empty element
+		// (which round-trips a final newline) exactly as-is.
+		if line == "" || strings.HasPrefix(line, "#") {
+			out = append(out, line)
+			continue
+		}
+		if rowExcluded(strings.Split(line, sep), addrIdx, setIdx, setSep, nets) {
+			dropped++
+			continue
+		}
+		out = append(out, line)
+	}
+
+	if dropped == 0 {
+		return nil
+	}
+	if err := os.WriteFile(logPath, []byte(strings.Join(out, "\n")), 0644); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	log.Printf("[processor] Subnet filter dropped %d row(s) from %s", dropped, filepath.Base(logPath))
+	return nil
+}
+
+// rowExcluded reports whether the row references an excluded-subnet IP in any
+// single-IP column (addrIdx) or any set-valued column (setIdx, split on setSep).
+func rowExcluded(cols []string, addrIdx, setIdx []int, setSep string, nets []*net.IPNet) bool {
+	for _, idx := range addrIdx {
+		if idx < len(cols) && ipInNets(cols[idx], nets) {
+			return true
+		}
+	}
+	for _, idx := range setIdx {
+		if idx >= len(cols) {
+			continue
+		}
+		cell := cols[idx]
+		if cell == "" || zeekUnsetMarkers[cell] {
+			continue
+		}
+		for _, v := range strings.Split(cell, setSep) {
+			if ipInNets(v, nets) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ipInNets reports whether val is a valid IP inside one of the excluded subnets.
+// Zeek unset markers and non-IP values (e.g. hostnames in a dns answers set)
+// return false.
+func ipInNets(val string, nets []*net.IPNet) bool {
+	if val == "" || zeekUnsetMarkers[val] {
+		return false
+	}
+	ip := net.ParseIP(val)
+	if ip == nil {
+		return false
+	}
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseSeparator decodes a Zeek "#separator" header line. Zeek writes the
+// separator as an escape (e.g. "#separator \x09" for tab) using a literal space
+// delimiter, since the separator cannot delimit its own definition. Defaults to
+// tab if the line is malformed.
+func parseSeparator(line string) string {
+	parts := strings.SplitN(line, " ", 2)
+	if len(parts) < 2 {
+		return "\t"
+	}
+	sep := strings.TrimSpace(parts[1])
+	if strings.HasPrefix(sep, `\x`) {
+		if b, err := strconv.ParseUint(sep[2:], 16, 8); err == nil {
+			return string(rune(b))
+		}
+	}
+	if sep == "" {
+		return "\t"
+	}
+	return sep
+}

--- a/internal/processor/common/subnet_filter_test.go
+++ b/internal/processor/common/subnet_filter_test.go
@@ -1,0 +1,270 @@
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// zeekHeader builds the standard Zeek TSV header for a log with the given path
+// name and #fields columns. The #separator line uses the literal "\x09" escape
+// exactly as Zeek writes it, so the filter's separator decoding is exercised.
+func zeekHeader(path string, fields ...string) []string {
+	return []string{
+		`#separator \x09`,
+		"#set_separator\t,",
+		"#empty_field\t(empty)",
+		"#unset_field\t-",
+		"#path\t" + path,
+		"#open\t2024-01-01-00-00-00",
+		"#fields\t" + strings.Join(fields, "\t"),
+		"#types\t" + strings.Repeat("string\t", len(fields)-1) + "string",
+	}
+}
+
+// writeLog joins header + data rows + a #close footer with a trailing newline
+// (matching real Zeek output) and writes it to runDir/name.
+func writeLog(t *testing.T, runDir, name string, header []string, rows ...string) string {
+	t.Helper()
+	lines := append([]string{}, header...)
+	lines = append(lines, rows...)
+	lines = append(lines, "#close\t2024-01-01-00-01-00", "")
+	p := filepath.Join(runDir, name)
+	if err := os.WriteFile(p, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func row(cols ...string) string { return strings.Join(cols, "\t") }
+
+// readDataRows returns the non-comment, non-empty rows of a log file.
+func readDataRows(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func TestFilterExcludedSubnets_ConnDropsBySrcOrDst(t *testing.T) {
+	dir := t.TempDir()
+	hdr := zeekHeader("conn", "ts", "uid", "id.orig_h", "id.orig_p", "id.resp_h", "id.resp_p", "proto")
+	path := writeLog(t, dir, "conn.log", hdr,
+		row("1", "CA", "10.1.2.3", "1234", "8.8.8.8", "53", "udp"),      // orig in 10/8 -> drop
+		row("2", "CB", "192.168.1.5", "5555", "10.5.5.5", "443", "tcp"), // resp in 10/8 -> drop
+		row("3", "CC", "192.168.1.5", "5555", "8.8.8.8", "443", "tcp"),  // neither -> keep
+	)
+
+	if err := FilterExcludedSubnets(dir, []string{"conn.log"}, []string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	rows := readDataRows(t, path)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row kept, got %d: %v", len(rows), rows)
+	}
+	if !strings.Contains(rows[0], "CC") {
+		t.Errorf("expected only row CC kept, got %q", rows[0])
+	}
+}
+
+func TestFilterExcludedSubnets_DHCPAddressColumns(t *testing.T) {
+	dir := t.TempDir()
+	// DHCP log with the dhcp-specific address columns and no id.orig_h/resp_h.
+	hdr := zeekHeader("dhcp", "ts", "uid", "mac", "client_addr", "server_addr", "requested_addr", "assigned_addr", "lease_time")
+	path := writeLog(t, dir, "dhcp.log", hdr,
+		// assigned_addr in 10/8 -> drop (client_addr unset)
+		row("1", "DA", "aa:bb:cc:dd:ee:01", "-", "192.168.1.1", "-", "10.0.0.50", "3600"),
+		// all address fields unset or out-of-range -> keep (unset markers skipped)
+		row("2", "DB", "aa:bb:cc:dd:ee:02", "-", "192.168.1.1", "(empty)", "-", "3600"),
+		// requested_addr in 10/8 -> drop
+		row("3", "DC", "aa:bb:cc:dd:ee:03", "192.168.1.9", "192.168.1.1", "10.9.9.9", "-", "3600"),
+	)
+
+	if err := FilterExcludedSubnets(dir, []string{"dhcp.log"}, []string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	rows := readDataRows(t, path)
+	if len(rows) != 1 || !strings.Contains(rows[0], "DB") {
+		t.Fatalf("expected only row DB kept, got %v", rows)
+	}
+}
+
+func TestFilterExcludedSubnets_PreservesHeadersAndFooter(t *testing.T) {
+	dir := t.TempDir()
+	hdr := zeekHeader("conn", "ts", "uid", "id.orig_h", "id.orig_p", "id.resp_h", "id.resp_p", "proto")
+	path := writeLog(t, dir, "conn.log", hdr,
+		row("1", "CA", "10.1.2.3", "1234", "8.8.8.8", "53", "udp"), // dropped
+	)
+	before, _ := os.ReadFile(path)
+
+	if err := FilterExcludedSubnets(dir, []string{"conn.log"}, []string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	after, _ := os.ReadFile(path)
+	afterStr := string(after)
+	// Every header/footer line must survive verbatim.
+	for _, want := range append(hdr, "#close\t2024-01-01-00-01-00") {
+		if !strings.Contains(afterStr, want) {
+			t.Errorf("header/footer line missing after filter: %q", want)
+		}
+	}
+	// Trailing newline preserved.
+	if !strings.HasSuffix(afterStr, "\n") {
+		t.Errorf("trailing newline not preserved")
+	}
+	// The data row must be gone.
+	if strings.Contains(afterStr, "\tCA\t") {
+		t.Errorf("dropped row still present")
+	}
+	if len(after) >= len(before) {
+		t.Errorf("expected file to shrink after dropping a row")
+	}
+}
+
+func TestFilterExcludedSubnets_FeatureOffLeavesFileUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	hdr := zeekHeader("conn", "ts", "uid", "id.orig_h", "id.orig_p", "id.resp_h", "id.resp_p", "proto")
+	path := writeLog(t, dir, "conn.log", hdr,
+		row("1", "CA", "10.1.2.3", "1234", "8.8.8.8", "53", "udp"),
+	)
+	before, _ := os.ReadFile(path)
+
+	// Empty CIDR list = feature off: no rows should be dropped.
+	if err := FilterExcludedSubnets(dir, []string{"conn.log"}, nil); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("file changed with feature off")
+	}
+}
+
+func TestFilterExcludedSubnets_MissingFileIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	// ja3_ja4.log / ja4s.log frequently absent (e.g. on Linux). Must not error.
+	if err := FilterExcludedSubnets(dir, []string{"ja3_ja4.log", "ja4s.log"}, []string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("expected no-op for missing files, got %v", err)
+	}
+}
+
+func TestFilterExcludedSubnets_DNSAnswers(t *testing.T) {
+	dir := t.TempDir()
+	// Client and resolver are NOT in the excluded range; only an answer is.
+	// This is the leak the answers coverage closes.
+	hdr := zeekHeader("dns", "ts", "uid", "id.orig_h", "id.orig_p", "id.resp_h", "id.resp_p", "proto", "query", "qtype_name", "answers")
+	path := writeLog(t, dir, "dns.log", hdr,
+		// answers set contains an excluded IP among a public one -> drop
+		row("1", "DNSA", "192.168.1.10", "5300", "192.168.1.1", "53", "udp", "db.corp", "A", "93.184.216.34,10.50.1.5"),
+		// answers has a CNAME hostname + an out-of-range IP -> keep
+		row("2", "DNSB", "192.168.1.10", "5300", "192.168.1.1", "53", "udp", "www.example.com", "A", "cname.example.com,93.184.216.34"),
+		// answers unset -> keep
+		row("3", "DNSC", "192.168.1.10", "5300", "192.168.1.1", "53", "udp", "x.corp", "A", "-"),
+	)
+
+	if err := FilterExcludedSubnets(dir, []string{"dns.log"}, []string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	rows := readDataRows(t, path)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows kept (DNSB, DNSC), got %d: %v", len(rows), rows)
+	}
+	for _, r := range rows {
+		if strings.Contains(r, "DNSA") {
+			t.Errorf("DNSA should have been dropped (answer 10.50.1.5 in excluded subnet): %q", r)
+		}
+	}
+}
+
+func TestFilterExcludedSubnets_DNSAnswersCustomSetSeparator(t *testing.T) {
+	dir := t.TempDir()
+	// A log declaring a non-comma #set_separator must still split answers correctly.
+	hdr := []string{
+		`#separator \x09`,
+		"#set_separator\t;",
+		"#empty_field\t(empty)",
+		"#unset_field\t-",
+		"#path\tdns",
+		"#open\t2024-01-01-00-00-00",
+		"#fields\tts\tuid\tid.orig_h\tid.resp_h\tanswers",
+		"#types\ttime\tstring\taddr\taddr\tset[string]",
+	}
+	path := writeLog(t, dir, "dns.log", hdr,
+		row("1", "S1", "192.168.1.10", "192.168.1.1", "8.8.8.8;10.0.0.9"), // second answer excluded -> drop
+		row("2", "S2", "192.168.1.10", "192.168.1.1", "8.8.8.8;1.1.1.1"),  // both public -> keep
+	)
+
+	if err := FilterExcludedSubnets(dir, []string{"dns.log"}, []string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	rows := readDataRows(t, path)
+	if len(rows) != 1 || !strings.Contains(rows[0], "S2") {
+		t.Fatalf("expected only row S2 kept, got %v", rows)
+	}
+}
+
+func TestFilterExcludedSubnets_IPv6(t *testing.T) {
+	dir := t.TempDir()
+	hdr := zeekHeader("conn", "ts", "uid", "id.orig_h", "id.orig_p", "id.resp_h", "id.resp_p", "proto")
+	path := writeLog(t, dir, "conn.log", hdr,
+		row("1", "V6A", "fd00::1", "1234", "2001:4860:4860::8888", "53", "udp"),      // orig in fd00::/8 -> drop
+		row("2", "V6B", "2606:4700::1", "1234", "2001:4860:4860::8888", "53", "udp"), // out of range -> keep
+	)
+
+	if err := FilterExcludedSubnets(dir, []string{"conn.log"}, []string{"fd00::/8"}); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	rows := readDataRows(t, path)
+	if len(rows) != 1 || !strings.Contains(rows[0], "V6B") {
+		t.Fatalf("expected only row V6B kept, got %v", rows)
+	}
+}
+
+// TestFilterExcludedSubnets_ReadErrorAborts pins the fail-closed contract: if a
+// present log cannot be read/parsed, filtering must return an error so the
+// caller aborts the window rather than uploading unfiltered data. Using a
+// directory in place of the log forces a non-NotExist read error deterministically,
+// independent of the test user's privileges.
+func TestFilterExcludedSubnets_ReadErrorAborts(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "conn.log"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := FilterExcludedSubnets(dir, []string{"conn.log"}, []string{"10.0.0.0/8"}); err == nil {
+		t.Fatal("expected an error when a log cannot be read (fail-closed), got nil")
+	}
+}
+
+func TestFilterExcludedSubnets_MultipleCIDRsAndTLSLog(t *testing.T) {
+	dir := t.TempDir()
+	hdr := zeekHeader("ja3_ja4", "ts", "uid", "id.orig_h", "id.resp_h", "ja3", "ja4")
+	path := writeLog(t, dir, "ja3_ja4.log", hdr,
+		row("1", "JA", "172.20.10.5", "1.1.1.1", "abc", "def"), // orig in 172.20.10.0/24 -> drop
+		row("2", "JB", "203.0.113.7", "1.1.1.1", "abc", "def"), // out of range -> keep
+	)
+
+	if err := FilterExcludedSubnets(dir, []string{"ja3_ja4.log"}, []string{"10.0.0.0/8", "172.20.10.0/24"}); err != nil {
+		t.Fatalf("FilterExcludedSubnets: %v", err)
+	}
+
+	rows := readDataRows(t, path)
+	if len(rows) != 1 || !strings.Contains(rows[0], "JB") {
+		t.Fatalf("expected only row JB kept, got %v", rows)
+	}
+}

--- a/internal/processor/linux/processor.go
+++ b/internal/processor/linux/processor.go
@@ -16,9 +16,6 @@ import (
 // zeekBinary is the path to the Zeek executable
 const zeekBinary = "/opt/zeek/bin/zeek"
 
-// zeekLogFiles are the Zeek logs we care about
-var zeekLogFiles = []string{"conn.log", "dns.log", "dhcp.log", "ja3_ja4.log", "ja4s.log"}
-
 // Dependency interfaces for testability
 // FS abstracts file system operations
 //go:generate mockgen -destination=fs_mock.go -package=linux . FS
@@ -83,14 +80,14 @@ func NewProcessorWithDeps(fs FS, cmdRunner CmdRunner, zeekPath string) *Processo
 }
 
 // ProcessPCAP runs Zeek on the given PCAP, converts logs to XLSX, and returns their paths
-func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error) {
+func (p *Processor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error) {
 	// Use the directory containing the PCAP as the run directory
 	runDir := filepath.Dir(pcapPath)
 	log.Printf("[processor] Run directory: %s", runDir)
 
 	// Prepare Zeek command with sampling if needed
 	baseArgs := []string{"-r", pcapPath, fmt.Sprintf("Log::default_logdir=%s", runDir), "-C"}
-	zeekArgs := types.PrepareZeekArgsWithSampling(pcapPath, runDir, samplingPercentage, baseArgs)
+	zeekArgs := types.PrepareZeekArgsWithSampling(pcapPath, runDir, opts.SamplingPercentage, baseArgs)
 
 	// Add DHCP fingerprint script if available so param_req_list appears in dhcp.log
 	fingerprintScriptPaths := []string{
@@ -124,7 +121,15 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 		log.Printf("[processor] Warning: DHCP enrichment failed: %v", err)
 	}
 
-	paths, err := types.RenameZeekLogsToXLSX(p.fs, runDir, zeekLogFiles)
+	// Drop any flows/records in an excluded subnet before the logs are renamed
+	// and uploaded. Fatal on failure: uploading unfiltered data would violate
+	// the "do not upload it" guarantee.
+	if err := types.FilterExcludedSubnets(runDir, types.ZeekLogFiles, opts.ExcludedSubnets); err != nil {
+		log.Printf("[processor] Subnet exclusion filtering failed: %v", err)
+		return types.ProcessedData{}, fmt.Errorf("subnet exclusion filtering failed: %w", err)
+	}
+
+	paths, err := types.RenameZeekLogsToXLSX(p.fs, runDir, types.ZeekLogFiles)
 	if err != nil {
 		log.Printf("[processor] Failed to rename Zeek logs: %v", err)
 		return types.ProcessedData{}, err
@@ -134,7 +139,7 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 		"zeek_out_dir":        runDir,
 		"timestamp":           time.Now().UTC().Format("20060102T150405Z"),
 		"pcap_path":           pcapPath,
-		"sampling_percentage": samplingPercentage,
+		"sampling_percentage": opts.SamplingPercentage,
 	}
 	log.Printf("[processor] Returning results: conn.xlsx=%s, dns.xlsx=%s, dhcp.xlsx=%s, ja3_ja4.xlsx=%s, ja4s.xlsx=%s, metadata=%v", paths["conn.log"], paths["dns.log"], paths["dhcp.log"], paths["ja3_ja4.log"], paths["ja4s.log"], metadata)
 

--- a/internal/processor/linux/processor_test.go
+++ b/internal/processor/linux/processor_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	types "EnigmaNetz/Enigma-Go-Sensor/internal/processor/common"
 )
 
 // TestProcessPCAP verifies that ProcessPCAP processes a valid PCAP file and produces non-empty XLSX log paths. Skips if the test PCAP file is not found.
@@ -19,7 +21,7 @@ func TestProcessPCAP(t *testing.T) {
 		t.Skip("Test PCAP file not found; skipping integration test.")
 	}
 
-	result, err := p.ProcessPCAP(pcapPath, 100)
+	result, err := p.ProcessPCAP(pcapPath, types.ProcessOptions{SamplingPercentage: 100})
 	if err != nil {
 		t.Fatalf("ProcessPCAP failed: %v", err)
 	}
@@ -50,7 +52,7 @@ func TestMetadataContent(t *testing.T) {
 	if _, err := os.Stat(pcapPath); os.IsNotExist(err) {
 		t.Skip("Test PCAP file not found; skipping integration test.")
 	}
-	result, err := p.ProcessPCAP(pcapPath, 100)
+	result, err := p.ProcessPCAP(pcapPath, types.ProcessOptions{SamplingPercentage: 100})
 	if err != nil {
 		t.Fatalf("ProcessPCAP failed: %v", err)
 	}

--- a/internal/processor/windows/processor.go
+++ b/internal/processor/windows/processor.go
@@ -54,7 +54,7 @@ func prepareWindowsZeekArgsWithSampling(runDir string, samplingPercentage float6
 	return args
 }
 
-func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error) {
+func (p *Processor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error) {
 	runDir := filepath.Dir(pcapPath)
 	zeekBaseDir := filepath.Join("zeek-windows", "zeek-runtime-win64")
 	zeekPath := filepath.Join(zeekBaseDir, "bin", "zeek.exe")
@@ -79,7 +79,7 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 	baseArgs := []string{"-r", zeekPcapPath, zeekScript, fmt.Sprintf("Log::default_logdir=%s", zeekRunDir), "-C"}
 
 	// For Windows, we handle sampling by modifying the search paths to use absolute paths
-	zeekArgs := prepareWindowsZeekArgsWithSampling(runDir, samplingPercentage, baseArgs)
+	zeekArgs := prepareWindowsZeekArgsWithSampling(runDir, opts.SamplingPercentage, baseArgs)
 
 	log.Printf("[processor] Running Zeek: %s %v", zeekPath, zeekArgs)
 
@@ -103,8 +103,15 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 		log.Printf("[processor] Warning: DHCP enrichment failed: %v", err)
 	}
 
-	logFiles := []string{"conn.log", "dns.log", "dhcp.log", "ja3_ja4.log", "ja4s.log"}
-	paths, err := types.RenameZeekLogsToXLSX(p.fs, runDir, logFiles)
+	// Drop any flows/records in an excluded subnet before the logs are renamed
+	// and uploaded. Fatal on failure: uploading unfiltered data would violate
+	// the "do not upload it" guarantee.
+	if err := types.FilterExcludedSubnets(runDir, types.ZeekLogFiles, opts.ExcludedSubnets); err != nil {
+		log.Printf("[processor] Subnet exclusion filtering failed: %v", err)
+		return types.ProcessedData{}, fmt.Errorf("subnet exclusion filtering failed: %w", err)
+	}
+
+	paths, err := types.RenameZeekLogsToXLSX(p.fs, runDir, types.ZeekLogFiles)
 	if err != nil {
 		log.Printf("[processor] Failed to rename Zeek logs: %v", err)
 		return types.ProcessedData{}, err
@@ -114,7 +121,7 @@ func (p *Processor) ProcessPCAP(pcapPath string, samplingPercentage float64) (ty
 		"zeek_out_dir":        runDir,
 		"timestamp":           time.Now().UTC().Format("20060102T150405Z"),
 		"pcap_path":           pcapPath,
-		"sampling_percentage": samplingPercentage,
+		"sampling_percentage": opts.SamplingPercentage,
 	}
 	log.Printf("[processor] Returning results: conn.xlsx=%s, dns.xlsx=%s, dhcp.xlsx=%s, ja3_ja4.xlsx=%s, ja4s.xlsx=%s, metadata=%v", paths["conn.log"], paths["dns.log"], paths["dhcp.log"], paths["ja3_ja4.log"], paths["ja4s.log"], metadata)
 

--- a/internal/processor/windows/processor_test.go
+++ b/internal/processor/windows/processor_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	types "EnigmaNetz/Enigma-Go-Sensor/internal/processor/common"
 )
 
 // mockCmd simulates exec.Cmd behavior for testing.
@@ -87,7 +89,7 @@ func TestProcessPCAP(t *testing.T) {
 	}
 	p := NewTestProcessor(mockExecCmd, fs)
 
-	result, err := p.ProcessPCAP(pcapPath, 100)
+	result, err := p.ProcessPCAP(pcapPath, types.ProcessOptions{SamplingPercentage: 100})
 	if err != nil {
 		t.Fatalf("ProcessPCAP failed: %v", err)
 	}

--- a/internal/sensor/sensor.go
+++ b/internal/sensor/sensor.go
@@ -34,7 +34,7 @@ type Capturer interface {
 }
 
 type Processor interface {
-	ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error)
+	ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error)
 }
 
 type Uploader interface {
@@ -351,7 +351,10 @@ func RunSensor(ctx context.Context, cfg *config.Config, capturer Capturer, proce
 			}
 			log.Printf("%s Processing PCAP file at absolute path: %s", prefix, absPCAPPath)
 
-			result, err := processor.ProcessPCAP(absPCAPPath, cfg.Zeek.SamplingPercentage)
+			result, err := processor.ProcessPCAP(absPCAPPath, types.ProcessOptions{
+				SamplingPercentage: cfg.Zeek.SamplingPercentage,
+				ExcludedSubnets:    cfg.ExcludedSubnetList(),
+			})
 			if err != nil {
 				log.Printf("%s Processing failed: %v", prefix, err)
 				deletePCAPFile(absPCAPPath, prefix)
@@ -402,6 +405,7 @@ func RunSensor(ctx context.Context, cfg *config.Config, capturer Capturer, proce
 			PollInterval:      time.Duration(cfg.PcapIngest.PollIntervalSeconds) * time.Second,
 			FileStableSeconds: cfg.PcapIngest.FileStableSeconds,
 			SamplingPct:       cfg.Zeek.SamplingPercentage,
+			ExcludedSubnets:   cfg.ExcludedSubnetList(),
 		}, processor, uploader)
 
 		wg.Add(1)

--- a/internal/sensor/sensor_test.go
+++ b/internal/sensor/sensor_test.go
@@ -44,7 +44,7 @@ type mockProcessor struct {
 	fail  bool
 }
 
-func (m *mockProcessor) ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error) {
+func (m *mockProcessor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error) {
 	atomic.AddInt32(m.calls, 1)
 	if m.fail {
 		return types.ProcessedData{}, errors.New("process failed")
@@ -74,7 +74,7 @@ type slowProcessor struct {
 	delay time.Duration
 }
 
-func (m *slowProcessor) ProcessPCAP(pcapPath string, samplingPercentage float64) (types.ProcessedData, error) {
+func (m *slowProcessor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (types.ProcessedData, error) {
 	atomic.AddInt32(m.calls, 1)
 	time.Sleep(m.delay)
 	return types.ProcessedData{


### PR DESCRIPTION
## Summary
Adds opt-in `zeek.excluded_subnets` to the Sensor. Any flow/record with an address inside a configured CIDR is dropped from the Zeek logs before upload, so excluded-subnet traffic never leaves the sensor. Empty = off (default). Go post-filter on the produced TSV logs. Ref B1CF-1830.

## Changes
- **Config:** `zeek.excluded_subnets`, comma-delimited CIDR string (e.g. `10.0.0.0/8,172.20.10.0/24`), validated with `net.ParseCIDR`. Stored as a string so it rides env overrides as `SENSOR_ZEEK_EXCLUDED_SUBNETS`.
- **Filter:** `FilterExcludedSubnets` in `processor/common` rewrites each uploaded log in place, after DHCP enrichment and before the XLSX rename, inside `ProcessPCAP` — one shared function covers both platforms and the live-capture + pcap-ingest paths.
- **Threading:** `ProcessPCAP(pcapPath, samplingPercentage)` → `ProcessPCAP(pcapPath, opts ProcessOptions)`.
- **Single source of truth:** `types.ZeekLogFiles` backs both the filter and the rename, so filtered set and uploaded set can't drift.

## Coverage
Columns located by `#fields` name, not index:
- conn / dns / ja3_ja4 / ja4s: `id.orig_h`, `id.resp_h`
- dhcp: `client_addr`, `server_addr`, `requested_addr`, `assigned_addr`
- dns `answers`: set-split on `#set_separator`; drops the row if any resolved IP is excluded, even when client/resolver are not.

Preserves `#` header/footer lines verbatim, skips unset markers (`-`, `(empty)`), IPv4 + IPv6, no-op on absent logs.

## Fail-closed
A filter error aborts the capture window (pcap dropped, nothing uploaded) rather than ship unfiltered data.

## Tests
- Filter: src/dst, DHCP columns, DNS answers (incl. non-default set-separator), IPv6, header/footer preservation, feature-off, missing-file no-op, multi-CIDR, fail-closed contract.
- Config: valid/malformed/IPv6 CIDR + `SENSOR_ZEEK_EXCLUDED_SUBNETS` override.
- `go test ./...` green; builds clean on linux/windows/darwin; gofmt clean.

Ref B1CF-1830