### PR TITLE
Emit JA3/JA4 fingerprints from Linux sensor Zeek processing

### DIFF
--- a/internal/processor/common/processor.go
+++ b/internal/processor/common/processor.go
@@ -75,24 +75,11 @@ func PrepareZeekArgsWithSampling(pcapPath, runDir string, samplingPercentage flo
 	args := make([]string, len(baseArgs))
 	copy(args, baseArgs)
 
-	// Add sampling script if sampling percentage is less than 100
+	// Add sampling script if sampling percentage is less than 100. Sampling is a
+	// special case of script discovery: the same candidate-path lookup, but it
+	// prepends a Sampling::sampling_percentage arg before the script path.
 	if samplingPercentage < 100 {
-		// Try to find the sampling script in various locations
-		possiblePaths := []string{
-			"zeek-scripts/sampling.zeek",
-			filepath.Join("..", "..", "zeek-scripts", "sampling.zeek"),
-			filepath.Join(filepath.Dir(pcapPath), "..", "..", "zeek-scripts", "sampling.zeek"),
-		}
-
-		var samplingScriptPath string
-		for _, path := range possiblePaths {
-			if _, err := os.Stat(path); err == nil {
-				samplingScriptPath = path
-				break
-			}
-		}
-
-		if samplingScriptPath != "" {
+		if samplingScriptPath := findZeekScript(OSFS{}, pcapPath, "sampling.zeek"); samplingScriptPath != "" {
 			args = append(args, fmt.Sprintf("Sampling::sampling_percentage=%.1f", samplingPercentage))
 			args = append(args, samplingScriptPath)
 			log.Printf("[processor] Added sampling script at %.1f%% from %s", samplingPercentage, samplingScriptPath)
@@ -102,4 +89,41 @@ func PrepareZeekArgsWithSampling(pcapPath, runDir string, samplingPercentage flo
 	}
 
 	return args
+}
+
+// zeekScriptCandidates returns the standard locations a bundled Zeek script named
+// `script` may live in, relative to the current working directory and to the pcap
+// directory. This is the single source of truth for where the sensor looks for
+// its zeek-scripts/ assets across sampling, DHCP, and JA3/JA4 discovery.
+func zeekScriptCandidates(pcapPath, script string) []string {
+	return []string{
+		filepath.Join("zeek-scripts", script),
+		filepath.Join("..", "..", "zeek-scripts", script),
+		filepath.Join(filepath.Dir(pcapPath), "..", "..", "zeek-scripts", script),
+	}
+}
+
+// findZeekScript returns the first candidate path for `script` that exists per fs,
+// or "" if none resolve.
+func findZeekScript(fs FS, pcapPath, script string) string {
+	for _, path := range zeekScriptCandidates(pcapPath, script) {
+		if _, err := fs.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// AppendZeekScriptIfFound locates the bundled Zeek script `script` and, if found,
+// appends its path to args and returns (args, true). If no candidate resolves it
+// returns (args, false) so the caller can decide how to report the miss (the
+// upload path tolerates missing logs, so a silent miss is easy to overlook).
+// Stat goes through the injected FS so the discovery loop stays unit-testable.
+func AppendZeekScriptIfFound(fs FS, args []string, pcapPath, script string) ([]string, bool) {
+	path := findZeekScript(fs, pcapPath, script)
+	if path == "" {
+		return args, false
+	}
+	log.Printf("[processor] Added Zeek script %s from %s", script, path)
+	return append(args, path), true
 }

--- a/internal/processor/linux/processor.go
+++ b/internal/processor/linux/processor.go
@@ -103,6 +103,23 @@ func (p *Processor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (typ
 		}
 	}
 
+	// Add JA3/JA4 fingerprint script if available so ja3_ja4.log / ja4s.log are
+	// produced (mirrors the Windows custom-scripts/main.zeek path). Without this
+	// the Linux sensor uploads empty JA3/JA4 payloads and TLS device-role
+	// classification never runs on Linux-sensor data.
+	ja3ja4ScriptPaths := []string{
+		"zeek-scripts/ja3-ja4-fingerprinting.zeek",
+		filepath.Join("..", "..", "zeek-scripts", "ja3-ja4-fingerprinting.zeek"),
+		filepath.Join(filepath.Dir(pcapPath), "..", "..", "zeek-scripts", "ja3-ja4-fingerprinting.zeek"),
+	}
+	for _, path := range ja3ja4ScriptPaths {
+		if _, err := os.Stat(path); err == nil {
+			zeekArgs = append(zeekArgs, path)
+			log.Printf("[processor] Added JA3/JA4 fingerprint script from %s", path)
+			break
+		}
+	}
+
 	log.Printf("[processor] Running Zeek: %s %v", p.zeekPath, zeekArgs)
 	cmd := p.cmdRunner.Command(p.zeekPath, zeekArgs...)
 	cmdStdout, ok := cmd.(*realCmd)

--- a/internal/processor/linux/processor.go
+++ b/internal/processor/linux/processor.go
@@ -89,35 +89,20 @@ func (p *Processor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (typ
 	baseArgs := []string{"-r", pcapPath, fmt.Sprintf("Log::default_logdir=%s", runDir), "-C"}
 	zeekArgs := types.PrepareZeekArgsWithSampling(pcapPath, runDir, opts.SamplingPercentage, baseArgs)
 
-	// Add DHCP fingerprint script if available so param_req_list appears in dhcp.log
-	fingerprintScriptPaths := []string{
-		"zeek-scripts/dhcp-fingerprint.zeek",
-		filepath.Join("..", "..", "zeek-scripts", "dhcp-fingerprint.zeek"),
-		filepath.Join(filepath.Dir(pcapPath), "..", "..", "zeek-scripts", "dhcp-fingerprint.zeek"),
-	}
-	for _, path := range fingerprintScriptPaths {
-		if _, err := os.Stat(path); err == nil {
-			zeekArgs = append(zeekArgs, path)
-			log.Printf("[processor] Added DHCP fingerprint script from %s", path)
-			break
-		}
-	}
+	// Add DHCP fingerprint script if available so param_req_list appears in dhcp.log.
+	zeekArgs, _ = types.AppendZeekScriptIfFound(p.fs, zeekArgs, pcapPath, "dhcp-fingerprint.zeek")
 
 	// Add JA3/JA4 fingerprint script if available so ja3_ja4.log / ja4s.log are
-	// produced (mirrors the Windows custom-scripts/main.zeek path). Without this
-	// the Linux sensor uploads empty JA3/JA4 payloads and TLS device-role
-	// classification never runs on Linux-sensor data.
-	ja3ja4ScriptPaths := []string{
-		"zeek-scripts/ja3-ja4-fingerprinting.zeek",
-		filepath.Join("..", "..", "zeek-scripts", "ja3-ja4-fingerprinting.zeek"),
-		filepath.Join(filepath.Dir(pcapPath), "..", "..", "zeek-scripts", "ja3-ja4-fingerprinting.zeek"),
-	}
-	for _, path := range ja3ja4ScriptPaths {
-		if _, err := os.Stat(path); err == nil {
-			zeekArgs = append(zeekArgs, path)
-			log.Printf("[processor] Added JA3/JA4 fingerprint script from %s", path)
-			break
-		}
+	// produced (mirrors the Windows custom-scripts/main.zeek path). Without it the
+	// Linux sensor uploads empty JA3/JA4 payloads and TLS device-role classification
+	// never runs on Linux-sensor data. Warn loudly on a miss: the upload path
+	// tolerates the missing logs, which would otherwise hide it entirely — notably
+	// on packaged systemd installs where CWD is / and zeek-scripts/ is not shipped.
+	var ja3ja4Found bool
+	zeekArgs, ja3ja4Found = types.AppendZeekScriptIfFound(p.fs, zeekArgs, pcapPath, "ja3-ja4-fingerprinting.zeek")
+	if !ja3ja4Found {
+		cwd, _ := os.Getwd()
+		log.Printf("[processor] WARNING: JA3/JA4 fingerprint script not found (cwd=%s, searched standard zeek-scripts locations); ja3_ja4.log/ja4s.log will be empty and TLS device-role classification cannot run", cwd)
 	}
 
 	log.Printf("[processor] Running Zeek: %s %v", p.zeekPath, zeekArgs)

--- a/internal/processor/linux/processor_test.go
+++ b/internal/processor/linux/processor_test.go
@@ -3,7 +3,9 @@
 package linux
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -62,6 +64,78 @@ func TestMetadataContent(t *testing.T) {
 	if ts, ok := result.Metadata["timestamp"]; !ok || !strings.Contains(ts.(string), "T") {
 		t.Error("Expected metadata to contain valid 'timestamp'")
 	}
+}
+
+// --- Unit test for the JA3/JA4 script discovery loop ---------------------------
+// These use the injected FS + CmdRunner seams (no real Zeek/filesystem) to assert
+// that the JA3/JA4 fingerprint script is passed to the Zeek invocation when the
+// file resolves, and omitted when it does not — guarding the discovery loop in
+// ProcessPCAP against regressions.
+
+// fakeFS reports any path containing `present` as existing and everything else as
+// missing, so the discovery loop is driven deterministically without the real FS.
+type fakeFS struct{ present string }
+
+func (f fakeFS) Stat(name string) (os.FileInfo, error) {
+	if f.present != "" && strings.Contains(name, f.present) {
+		return nil, nil
+	}
+	return nil, os.ErrNotExist
+}
+func (fakeFS) MkdirAll(string, os.FileMode) error { return nil }
+func (fakeFS) Open(string) (*os.File, error)      { return nil, os.ErrNotExist }
+func (fakeFS) Create(string) (*os.File, error)    { return nil, os.ErrNotExist }
+func (fakeFS) Rename(string, string) error        { return nil }
+
+// capturingCmdRunner records the args handed to Command. The fingerprint scripts
+// are appended before Command is called, so Run can abort immediately (returning
+// an error) without affecting what was captured.
+type capturingCmdRunner struct{ args []string }
+
+func (r *capturingCmdRunner) Command(name string, arg ...string) Cmd {
+	r.args = arg
+	return stubCmd{}
+}
+
+type stubCmd struct{}
+
+func (stubCmd) Run() error { return fmt.Errorf("stub: skipping real zeek execution") }
+
+func argsContain(args []string, substr string) bool {
+	for _, a := range args {
+		if strings.Contains(a, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProcessPCAP_JA3JA4ScriptDiscovery(t *testing.T) {
+	const script = "ja3-ja4-fingerprinting.zeek"
+	pcapPath := filepath.Join(t.TempDir(), "test.pcap")
+
+	t.Run("script present is passed to zeek", func(t *testing.T) {
+		runner := &capturingCmdRunner{}
+		p := NewProcessorWithDeps(fakeFS{present: script}, runner, zeekBinary)
+
+		// Run() errors to skip real Zeek; args were already captured at Command().
+		_, _ = p.ProcessPCAP(pcapPath, types.ProcessOptions{SamplingPercentage: 100})
+
+		if !argsContain(runner.args, script) {
+			t.Fatalf("expected zeek args to include %q, got: %v", script, runner.args)
+		}
+	})
+
+	t.Run("script absent is not passed", func(t *testing.T) {
+		runner := &capturingCmdRunner{}
+		p := NewProcessorWithDeps(fakeFS{present: ""}, runner, zeekBinary)
+
+		_, _ = p.ProcessPCAP(pcapPath, types.ProcessOptions{SamplingPercentage: 100})
+
+		if argsContain(runner.args, script) {
+			t.Fatalf("expected zeek args to omit %q when the file is missing, got: %v", script, runner.args)
+		}
+	})
 }
 
 // TODO: Add more granular unit tests with mocks for Zeek and file conversion.

--- a/zeek-scripts/ja3-ja4-fingerprinting.zeek
+++ b/zeek-scripts/ja3-ja4-fingerprinting.zeek
@@ -1,0 +1,265 @@
+@load base/protocols/ssl
+@load base/protocols/http
+
+module JA3JA4Fingerprinting;
+
+export {
+    # Define a new log stream for JA3/JA4 fingerprints
+    redef enum Log::ID += { JA3JA4_LOG };
+
+    # Define the record that will contain our JA3/JA4 fingerprint information
+    type Info: record {
+        ts: time &log;
+        uid: string &log;
+        id: conn_id &log;
+        ja3: string &log &optional;
+        ja3_hash: string &log &optional;
+        ja4: string &log &optional;
+        ja4_hash: string &log &optional;
+        client_version: string &log &optional;
+        cipher_suites: vector of string &log &optional;
+        extensions: vector of string &log &optional;
+        server_name: string &log &optional;
+        user_agent: string &log &optional;
+    };
+
+    # Global table to store JA3/JA4 fingerprints
+    global ja3_ja4_fingerprints: table[string] of Info &read_expire=1day;
+
+    # Add JA4S record type
+    type JA4SInfo: record {
+        ts: time &log;
+        uid: string &log;
+        id: conn_id &log;
+        ja4s: string &log;
+        ja4s_hash: string &log;
+        server_version: string &log;
+        server_cipher: string &log;
+        server_extensions: vector of string &log;
+        server_name: string &log;
+    };
+
+    # Add JA4S log stream
+    redef enum Log::ID += { JA4S_LOG };
+
+    # Global table to store server extensions
+    global server_extensions: table[string] of vector of string;
+}
+
+# Function to calculate JA3 fingerprint
+function calculate_ja3(c: connection, version: string, cipher_suites: vector of string, extensions: vector of string): string {
+    local ja3 = fmt("%s,%s,%s",
+        version,
+        join_string_vec(cipher_suites, "-"),
+        join_string_vec(extensions, "-"));
+    return ja3;
+}
+
+# Function to calculate JA4 fingerprint
+function calculate_ja4(c: connection, version: string, cipher_suites: vector of string, extensions: vector of string, user_agent: string &optional): string {
+    # JA4 format: t{version}_{cipher_suites}_{extensions}_{user_agent_hash}
+    local user_agent_hash = "0";
+    if (user_agent != "") {
+        user_agent_hash = md5_hash(user_agent);
+    }
+    local ja4 = fmt("t%s_%s_%s_%s",
+        version,
+        join_string_vec(cipher_suites, "-"),
+        join_string_vec(extensions, "-"),
+        user_agent_hash);
+    return ja4;
+}
+
+# Function to calculate JA4S fingerprint
+function calculate_ja4s(c: connection, version: string, cipher: string, extensions: vector of string): string {
+    local ja4s = fmt("t%s_%s_%s",
+        version,
+        cipher,
+        join_string_vec(extensions, "-"));
+    return ja4s;
+}
+
+# Initialize the log stream
+event zeek_init() {
+    # Create the log stream with the correct parameters
+    Log::create_stream(JA3JA4Fingerprinting::JA3JA4_LOG, [
+        $columns=Info,
+        $path="ja3_ja4"
+    ]);
+
+    # Initialize JA4S log
+    Log::create_stream(JA4S_LOG, [$columns=JA4SInfo, $path="ja4s"]);
+}
+
+# Event handler for SSL/TLS Client Hello messages
+event ssl_client_hello(c: connection, version: count, record_version: count, possible_ts: time, client_random: string, session_id: string, ciphers: index_vec, comp_methods: index_vec) {
+    local info: Info;
+
+    # Use existing info if available, otherwise create new
+    if (c$uid in ja3_ja4_fingerprints) {
+        info = ja3_ja4_fingerprints[c$uid];
+    } else {
+        info$ts = c$start_time;
+        info$uid = c$uid;
+        info$id = c$id;
+    }
+
+    info$client_version = fmt("%d", version);
+
+    # Convert cipher suites to strings
+    local cipher_suites: vector of string;
+    for (idx in ciphers) {
+        cipher_suites += fmt("%d", ciphers[idx]);
+    }
+    info$cipher_suites = cipher_suites;
+
+    # Get extensions from SSL history and other SSL fields
+    local extensions: vector of string;
+
+    # Add server_name extension if SNI is present
+    if (c$ssl?$server_name) {
+        extensions += "0";  # server_name extension
+        info$server_name = c$ssl$server_name;
+    }
+
+    # Add session_ticket extension if session was resumed
+    if (c$ssl?$resumed && c$ssl$resumed) {
+        extensions += "35";  # session_ticket extension
+    }
+
+    # Add supported_groups extension if curve is present
+    if (c$ssl?$curve && c$ssl$curve != "") {
+        extensions += "10";  # supported_groups extension
+    }
+
+    # Add signature_algorithms extension (common in TLS 1.3)
+    if (version >= 0x0304) {  # TLS 1.3
+        extensions += "13";  # signature_algorithms extension
+    }
+
+    # Add key_share extension (required for TLS 1.3)
+    if (version >= 0x0304) {  # TLS 1.3
+        extensions += "51";  # key_share extension
+    }
+
+    # Add supported_versions extension (required for TLS 1.3)
+    if (version >= 0x0304) {  # TLS 1.3
+        extensions += "43";  # supported_versions extension
+    }
+
+    # Add application_layer_protocol_negotiation extension if present
+    if (c$ssl?$next_protocol && c$ssl$next_protocol != "") {
+        extensions += "16";  # application_layer_protocol_negotiation extension
+    }
+
+    info$extensions = extensions;
+
+    # Calculate JA3
+    if (|cipher_suites| > 0 && |extensions| > 0) {
+        info$ja3 = calculate_ja3(c, info$client_version, cipher_suites, extensions);
+        info$ja3_hash = md5_hash(info$ja3);
+
+        # Only write to log if this is a new connection
+        if (!(c$uid in ja3_ja4_fingerprints)) {
+            Log::write(JA3JA4Fingerprinting::JA3JA4_LOG, info);
+        }
+    }
+
+    # Store the fingerprint information
+    ja3_ja4_fingerprints[c$uid] = info;
+}
+
+# Event handler for HTTP User-Agent headers
+event http_header(c: connection, is_orig: bool, name: string, value: string) {
+    if (name == "USER-AGENT" && is_orig) {
+        # Try to find the SSL connection that corresponds to this HTTP connection
+        local matching_uid = "";
+        local matching_fingerprint: Info;
+
+        # First try to match by UID
+        if (c$uid in ja3_ja4_fingerprints) {
+            matching_uid = c$uid;
+            matching_fingerprint = ja3_ja4_fingerprints[c$uid];
+        }
+
+        # If no match by UID, try to match by IP and port
+        if (matching_uid == "") {
+            for (uid, fingerprint in ja3_ja4_fingerprints) {
+                if (fingerprint$id$orig_h == c$id$orig_h &&
+                    fingerprint$id$orig_p == c$id$orig_p) {
+                    matching_uid = uid;
+                    matching_fingerprint = fingerprint;
+                    break;
+                }
+            }
+        }
+
+        # If we found a match, update the fingerprint with the User-Agent
+        if (matching_uid != "") {
+            matching_fingerprint$user_agent = value;
+
+            # Calculate JA4 if we have all required data
+            if (matching_fingerprint?$client_version &&
+                matching_fingerprint?$cipher_suites &&
+                matching_fingerprint?$extensions) {
+
+                matching_fingerprint$ja4 = calculate_ja4(
+                    c,
+                    matching_fingerprint$client_version,
+                    matching_fingerprint$cipher_suites,
+                    matching_fingerprint$extensions,
+                    value
+                );
+                matching_fingerprint$ja4_hash = md5_hash(matching_fingerprint$ja4);
+
+                # Update the stored fingerprint
+                ja3_ja4_fingerprints[matching_uid] = matching_fingerprint;
+
+                # Write to log
+                Log::write(JA3JA4Fingerprinting::JA3JA4_LOG, matching_fingerprint);
+            }
+        }
+    }
+}
+
+# Event handler for SSL/TLS Server Hello messages
+event ssl_server_hello(c: connection, version: count, record_version: count, possible_ts: time, server_random: string, session_id: string, cipher: count, comp_method: count) {
+    local info: JA4SInfo;
+    info$ts = c$start_time;
+    info$uid = c$uid;
+    info$id = c$id;
+    info$server_version = fmt("%d", version);
+    info$server_cipher = fmt("%d", cipher);
+
+    # Get server extensions if available
+    if (c$uid in server_extensions) {
+        info$server_extensions = server_extensions[c$uid];
+    } else {
+        info$server_extensions = vector();
+    }
+
+    # Get server name if available
+    if (c$ssl?$server_name) {
+        info$server_name = c$ssl$server_name;
+    } else {
+        info$server_name = "Unknown";
+    }
+
+    # Calculate JA4S
+    info$ja4s = calculate_ja4s(c, info$server_version, info$server_cipher, info$server_extensions);
+    info$ja4s_hash = md5_hash(info$ja4s);
+
+    # Write to log
+    Log::write(JA4S_LOG, info);
+}
+
+# Event handler for SSL/TLS extensions
+event ssl_extension(c: connection, is_orig: bool, code: count, val: string) {
+    if (!is_orig) {  # Server extensions
+        if (c$uid in server_extensions) {
+            server_extensions[c$uid] += fmt("%d", code);
+        } else {
+            server_extensions[c$uid] = vector(fmt("%d", code));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The Linux sensor never produced JA3/JA4 fingerprints, so `ja3_ja4.log` / `ja4s.log` were always empty and the `enigma-tls-fingerprints` table received no JA3/JA4 data. This blocked TLS device-role classification (Client/Server/Both) end to end on Linux — the preferred production sensor platform.

Root cause: the Linux Zeek invocation loaded only `sampling.zeek` + `dhcp-fingerprint.zeek`, with no JA3/JA4 script. The Windows path already emits these logs by loading `site/custom-scripts/main.zeek` (bundled in `zeek-runtime-win64.zip`); Linux had no equivalent.

## Changes
- Add `zeek-scripts/ja3-ja4-fingerprinting.zeek` — the same script the Windows runtime bundles, minus the Windows-only `cmd.exe` log-cleanup line in `zeek_init`. Depends only on stock Zeek (`base/protocols/ssl`, `base/protocols/http`).
- Load it in `internal/processor/linux/processor.go` via the same file-discovery loop already used for `dhcp-fingerprint.zeek`.

No Dockerfile change: `COPY zeek-scripts/` already ships it, and the script needs no zkg package or compiled plugin.

## Verification
Ran the sensor image's Zeek against a live TLS capture (~3 HTTPS handshakes):
- Before: `ssl.log` had rows, `ja3_ja4.log` had 0.
- After: `ssl.log`, `ja3_ja4.log`, `ja4s.log` all populated with matching row counts.
- `ja3` / `ja3_hash` and `ja4s` / `ja4s_hash` populated with `server_name`; `ja4` remains empty (expected — requires a cleartext HTTP User-Agent, same as Windows).
- `#fields` header is byte-identical to the Windows-bundled `ja3_ja4.log` (LF vs CRLF only), so Linux data lands in the same schema Windows produces.

## Notes for reviewers
- This ports the **existing** fingerprint behavior for Windows↔Linux parity. These are the project's homegrown fingerprints, not standard FoxIO JA3/JA4 — sufficient because the only consumer (`tls_device_classifier.py`) uses them as presence/absence signals for device role, not for threat-intel matching. Real standardized JA3/JA4 would be a separate change touching both platforms.
- CI runs the per-OS `go test` matrix; the change is confined to the Linux processor path plus a non-compiled `.zeek` asset.

Ref B1CF-1838