### PR TITLE
Surface Zeek failure output and make sensor resource growth observable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ zeek-windows/
 .claude/
 results/
 .mcp.json
+.projects/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,6 +45,18 @@ go build -o bin/enigma-sensor ./cmd/enigma-sensor
 - Windows (installed): `C:\\ProgramData\\EnigmaSensor\\config.json`
 - Repo/local dev: `./config.json`
 
+### Capture Worker Sizing
+
+`capture.max_processing_workers` caps how many PCAPs are processed concurrently. Each worker can run a Zeek child that allocates hundreds of MB, so this setting is the main lever on the sensor's peak memory.
+
+The key is optional. Omitting it (the shipped `config.example.json` default) or setting it to 0 makes the sensor derive the value from available host memory on Linux (available MB divided by 768 MB per worker, clamped to 1-10); previously this was a flat 10. Available MB is the minimum of `/proc/meminfo` and any cgroup memory limit (cgroup v2 `memory.max`, falling back to cgroup v1 `memory.limit_in_bytes`), so a containerized or systemd `MemoryMax=`-limited sensor sizes against its own limit rather than the host's full memory. On non-Linux hosts the derived default stays 10, since available memory is not read there. Set the key explicitly (1-20) only to override the derived value; the sensor logs a warning if an explicit value looks too high for the host's available memory.
+
+On RAM-constrained hosts, an explicit value of 1-2 can still be set if the sensor or its Zeek children are being OOM-killed despite the memory-scaled default.
+
+### Self-Metrics Logging
+
+The sensor logs a `[selfmetrics] ...` line every 5 minutes with its own RSS, open file descriptor count, OS thread count, goroutine count, Go heap allocation, and the number of `zeek_out_*` directories in the capture output directory. Useful for spotting resource growth on a long-running sensor. There is no config knob for this; the interval is fixed. The count only covers `capture.output_dir`; PCAPs handled by the optional pcap-ingest watcher (`pcap_ingest.watch_dir`) are processed in their own `processing/` subdirectory and are not reflected in this gauge.
+
 ## Log Locations
 
 - Linux (installed): `/var/log/enigma-sensor/enigma-sensor.log`

--- a/config/config.go
+++ b/config/config.go
@@ -3,11 +3,44 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"regexp"
 	"strings"
 )
+
+const (
+	// maxDefaultProcessingWorkers is the historical default worker count and the
+	// ceiling the memory-scaled default is clamped to.
+	maxDefaultProcessingWorkers = 10
+	// memoryMBPerProcessingWorker is the rough memory budget for one worker and
+	// the Zeek child it runs.
+	memoryMBPerProcessingWorker = 768
+)
+
+// availableMemoryMB reports the host memory available for processing workers in
+// MB. The second return is false when the host memory cannot be determined.
+// It is a package var so tests can stub it.
+var availableMemoryMB = hostAvailableMemoryMB
+
+// defaultProcessingWorkers derives the default worker count from available host
+// memory, clamped to [1, maxDefaultProcessingWorkers]. When host memory is
+// unknown it keeps the historical default.
+func defaultProcessingWorkers() int {
+	mb, known := availableMemoryMB()
+	if !known {
+		return maxDefaultProcessingWorkers
+	}
+	workers := mb / memoryMBPerProcessingWorker
+	if workers < 1 {
+		return 1
+	}
+	if workers > maxDefaultProcessingWorkers {
+		return maxDefaultProcessingWorkers
+	}
+	return int(workers)
+}
 
 // Config represents the application configuration
 type Config struct {
@@ -190,9 +223,13 @@ func (config *Config) ValidateAndSetDefaults() error {
 		config.Capture.Interface = "any"
 	}
 	if config.Capture.MaxProcessingWorkers == 0 {
-		config.Capture.MaxProcessingWorkers = 10
+		config.Capture.MaxProcessingWorkers = defaultProcessingWorkers()
 	} else if config.Capture.MaxProcessingWorkers < 1 || config.Capture.MaxProcessingWorkers > 20 {
 		return fmt.Errorf("capture.max_processing_workers must be between 1 and 20, got %d", config.Capture.MaxProcessingWorkers)
+	} else if recommended := defaultProcessingWorkers(); config.Capture.MaxProcessingWorkers > recommended {
+		if _, known := availableMemoryMB(); known {
+			log.Printf("WARNING: capture.max_processing_workers is set to %d but available host memory supports about %d worker(s); each worker can run a Zeek child, so this may lead to out-of-memory kills", config.Capture.MaxProcessingWorkers, recommended)
+		}
 	}
 	// Validate Capture RetentionHours: nil means "not configured" (fall back to log_retention_days), 0 = immediate cleanup, max 720
 	if config.Capture.RetentionHours != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,12 @@
 package config
 
 import (
+	"bytes"
+	"log"
+	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -652,4 +657,247 @@ func TestConfig_ValidateAndSetDefaults_NetworkID(t *testing.T) {
 	if cfg.NetworkID != "Trimmed-Network" {
 		t.Errorf("Expected network_id to be trimmed to 'Trimmed-Network', got %q", cfg.NetworkID)
 	}
+}
+
+// stubAvailableMemory replaces the host memory probe for the duration of the
+// test and restores the real one afterwards.
+func stubAvailableMemory(t *testing.T, mb int, known bool) {
+	t.Helper()
+	orig := availableMemoryMB
+	availableMemoryMB = func() (uint64, bool) { return uint64(mb), known }
+	t.Cleanup(func() { availableMemoryMB = orig })
+}
+
+// TestDefaultProcessingWorkers_MemoryScaling verifies the default worker count
+// scales with available memory and stays inside [1, maxDefaultProcessingWorkers].
+// Each Zeek worker costs roughly memoryMBPerProcessingWorker, so an unscaled
+// default of 10 is what OOM-kills small hosts.
+func TestDefaultProcessingWorkers_MemoryScaling(t *testing.T) {
+	tests := []struct {
+		name     string
+		memoryMB int
+		known    bool
+		expected int
+	}{
+		{"unknown memory keeps the historical default", 0, false, 10},
+		{"16GB clamps at the maximum", 16384, true, 10},
+		{"8GB clamps at the maximum", 8192, true, 10},
+		{"2GB scales down to 2", 2048, true, 2},
+		{"1GB scales down to 1", 1024, true, 1},
+		{"256MB floors at 1, never 0", 256, true, 1},
+		{"0MB known still floors at 1", 0, true, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubAvailableMemory(t, tt.memoryMB, tt.known)
+			if got := defaultProcessingWorkers(); got != tt.expected {
+				t.Errorf("defaultProcessingWorkers() with %dMB (known=%v) = %d, want %d", tt.memoryMB, tt.known, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestConfig_ValidateAndSetDefaults_MaxProcessingWorkers verifies the config
+// default is memory-scaled while an explicitly configured value is respected
+// and still range-validated.
+func TestConfig_ValidateAndSetDefaults_MaxProcessingWorkers(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       int
+		memoryMB    int
+		known       bool
+		expected    int
+		expectError bool
+		errorMsg    string
+	}{
+		{"zero with unknown memory defaults to 10", 0, 0, false, 10, false, ""},
+		{"zero with 16GB defaults to 10", 0, 16384, true, 10, false, ""},
+		{"zero with 2GB defaults to 2", 0, 2048, true, 2, false, ""},
+		{"zero with 1GB defaults to 1", 0, 1024, true, 1, false, ""},
+		{"zero with 256MB defaults to 1", 0, 256, true, 1, false, ""},
+		{"explicit 15 preserved on a low-memory host", 15, 512, true, 15, false, ""},
+		{"explicit 1 preserved on a big host", 1, 16384, true, 1, false, ""},
+		{"explicit 20 preserved", 20, 16384, true, 20, false, ""},
+		{"explicit 25 still fails validation", 25, 16384, true, 25, true, "must be between 1 and 20"},
+		{"explicit negative still fails validation", -1, 16384, true, -1, true, "must be between 1 and 20"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubAvailableMemory(t, tt.memoryMB, tt.known)
+			cfg := &Config{NetworkID: "Test-Network-01"}
+			cfg.Capture.MaxProcessingWorkers = tt.input
+			err := cfg.ValidateAndSetDefaults()
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("Expected error for MaxProcessingWorkers=%d, got nil", tt.input)
+				}
+				if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error to contain %q, got %q", tt.errorMsg, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error for MaxProcessingWorkers=%d: %v", tt.input, err)
+			}
+			if cfg.Capture.MaxProcessingWorkers != tt.expected {
+				t.Errorf("MaxProcessingWorkers: input %d, memory %dMB, expected %d, got %d", tt.input, tt.memoryMB, tt.expected, cfg.Capture.MaxProcessingWorkers)
+			}
+		})
+	}
+}
+
+// TestDefaultProcessingWorkers_UsesDeclaredConstants ties the expectations above
+// to the declared constants so the test fails loudly if either is retuned
+// without revisiting the scaling behaviour.
+func TestDefaultProcessingWorkers_UsesDeclaredConstants(t *testing.T) {
+	stubAvailableMemory(t, memoryMBPerProcessingWorker*3, true)
+	if got := defaultProcessingWorkers(); got != 3 {
+		t.Errorf("defaultProcessingWorkers() with exactly 3 workers worth of memory = %d, want 3", got)
+	}
+	stubAvailableMemory(t, memoryMBPerProcessingWorker*maxDefaultProcessingWorkers*4, true)
+	if got := defaultProcessingWorkers(); got != maxDefaultProcessingWorkers {
+		t.Errorf("defaultProcessingWorkers() on a huge host = %d, want %d", got, maxDefaultProcessingWorkers)
+	}
+}
+
+// syncBuffer is a mutex-guarded bytes.Buffer so the standard logger can be
+// redirected into it without tripping the race detector.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// captureConfigLogs redirects the standard logger into a buffer for the duration
+// of the test and restores it afterwards.
+func captureConfigLogs(t *testing.T) *syncBuffer {
+	t.Helper()
+	buf := &syncBuffer{}
+	log.SetOutput(buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	return buf
+}
+
+// TestConfig_ValidateAndSetDefaults_LowMemoryWarning covers the advisory warning
+// emitted when an explicitly configured worker count exceeds what the detected
+// host memory supports. Nothing else asserts this branch, so without these cases
+// the whole warning could be deleted with every config test still green.
+func TestConfig_ValidateAndSetDefaults_LowMemoryWarning(t *testing.T) {
+	tests := []struct {
+		name        string
+		workers     int
+		memoryMB    int
+		known       bool
+		wantWarning bool
+	}{
+		{"explicit 15 on a 512MB host warns", 15, 512, true, true},
+		{"explicit 10 on a 1GB host warns", 10, 1024, true, true},
+		{"explicit 1 with plenty of memory does not warn", 1, 16384, true, false},
+		{"explicit 10 with plenty of memory does not warn", 10, 16384, true, false},
+		{"explicit value equal to the recommendation does not warn", 2, 2048, true, false},
+		{"explicit 15 with unknown memory does not warn", 15, 0, false, false},
+		{"explicit 20 with unknown memory does not warn", 20, 0, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubAvailableMemory(t, tt.memoryMB, tt.known)
+			buf := captureConfigLogs(t)
+
+			cfg := &Config{NetworkID: "Test-Network-01"}
+			cfg.Capture.MaxProcessingWorkers = tt.workers
+			if err := cfg.ValidateAndSetDefaults(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			logged := buf.String()
+			warned := strings.Contains(logged, "capture.max_processing_workers is set to")
+
+			if warned != tt.wantWarning {
+				t.Fatalf("warning emitted = %v, want %v (workers=%d, memory=%dMB, known=%v); log was %q",
+					warned, tt.wantWarning, tt.workers, tt.memoryMB, tt.known, logged)
+			}
+			if !tt.wantWarning {
+				return
+			}
+
+			for _, want := range []string{
+				"WARNING",
+				"capture.max_processing_workers",
+				"available host memory supports about",
+				"out-of-memory",
+			} {
+				if !strings.Contains(logged, want) {
+					t.Errorf("warning %q missing expected text %q", logged, want)
+				}
+			}
+			if !strings.Contains(logged, "set to "+itoa(tt.workers)) {
+				t.Errorf("warning %q does not name the configured value %d", logged, tt.workers)
+			}
+			// The configured value must be preserved; the branch only advises.
+			if cfg.Capture.MaxProcessingWorkers != tt.workers {
+				t.Errorf("MaxProcessingWorkers = %d, want the configured %d", cfg.Capture.MaxProcessingWorkers, tt.workers)
+			}
+		})
+	}
+}
+
+// TestConfig_ValidateAndSetDefaults_LowMemoryWarningNamesRecommendation pins the
+// recommended count carried in the warning, so a mutation that logs the
+// configured value twice (or a constant) fails.
+func TestConfig_ValidateAndSetDefaults_LowMemoryWarningNamesRecommendation(t *testing.T) {
+	// 3 workers' worth of memory, with 15 configured.
+	stubAvailableMemory(t, memoryMBPerProcessingWorker*3, true)
+	buf := captureConfigLogs(t)
+
+	cfg := &Config{NetworkID: "Test-Network-01"}
+	cfg.Capture.MaxProcessingWorkers = 15
+	if err := cfg.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "set to 15") {
+		t.Errorf("warning %q does not name the configured 15", logged)
+	}
+	if !strings.Contains(logged, "about 3 worker(s)") {
+		t.Errorf("warning %q does not name the recommended 3 workers", logged)
+	}
+}
+
+// TestConfig_ValidateAndSetDefaults_NoWarningWhenDefaulted verifies the warning
+// never fires for the zero (auto-default) case, where the derived value is by
+// construction within the memory budget.
+func TestConfig_ValidateAndSetDefaults_NoWarningWhenDefaulted(t *testing.T) {
+	stubAvailableMemory(t, 512, true)
+	buf := captureConfigLogs(t)
+
+	cfg := &Config{NetworkID: "Test-Network-01"}
+	cfg.Capture.MaxProcessingWorkers = 0
+	if err := cfg.ValidateAndSetDefaults(); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if logged := buf.String(); strings.Contains(logged, "capture.max_processing_workers is set to") {
+		t.Errorf("did not expect a low-memory warning when the value was auto-defaulted, got %q", logged)
+	}
+}
+
+// itoa is a tiny local helper so the assertions above can build the exact
+// substring the warning is expected to contain.
+func itoa(n int) string {
+	return strconv.Itoa(n)
 }

--- a/config/hostmem_linux.go
+++ b/config/hostmem_linux.go
@@ -1,0 +1,124 @@
+//go:build linux
+
+package config
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// kbPerMB converts /proc/meminfo values, which are reported in kB.
+	kbPerMB = 1024
+	// bytesPerMB converts cgroup limit files, which are reported in bytes.
+	bytesPerMB = 1024 * 1024
+	// cgroupUnlimited is the threshold above which a cgroup byte limit is
+	// treated as "no limit". cgroup v1 writes a huge sentinel (commonly
+	// 9223372036854771712) rather than an explicit "max".
+	cgroupUnlimited = uint64(1) << 62
+
+	cgroupV2LimitPath = "/sys/fs/cgroup/memory.max"
+	cgroupV1LimitPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+)
+
+// hostAvailableMemoryMB returns the memory budget this process should size itself
+// against: the minimum of the host's available memory and any cgroup memory limit
+// applied to it. Inside a container /proc/meminfo still reports the host's memory,
+// so the cgroup limit is what actually gets the process OOM-killed.
+// Returns (0, false) when it cannot be determined.
+func hostAvailableMemoryMB() (uint64, bool) {
+	hostMB, hostKnown := readMeminfoMB()
+	limitMB, limitKnown := readCgroupLimitMB()
+
+	switch {
+	case hostKnown && limitKnown:
+		if limitMB < hostMB {
+			return limitMB, true
+		}
+		return hostMB, true
+	case hostKnown:
+		return hostMB, true
+	case limitKnown:
+		return limitMB, true
+	default:
+		return 0, false
+	}
+}
+
+// readMeminfoMB reads /proc/meminfo, degrading to unknown on any read failure.
+func readMeminfoMB() (uint64, bool) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	return parseMeminfoMB(f)
+}
+
+// readCgroupLimitMB reads the cgroup v2 memory limit, falling back to the v1 path
+// when v2 is absent. Any read failure degrades to unknown.
+func readCgroupLimitMB() (uint64, bool) {
+	if b, err := os.ReadFile(cgroupV2LimitPath); err == nil {
+		return parseCgroupLimitMB(string(b))
+	}
+	if b, err := os.ReadFile(cgroupV1LimitPath); err == nil {
+		return parseCgroupLimitMB(string(b))
+	}
+	return 0, false
+}
+
+// parseMeminfoMB parses /proc/meminfo content, preferring MemAvailable and falling
+// back to MemTotal. Values in /proc/meminfo are in kB. Returns (0, false) if
+// neither is present or parseable.
+func parseMeminfoMB(r io.Reader) (uint64, bool) {
+	var totalKB uint64
+	var totalKnown bool
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "MemAvailable:":
+			kb, err := strconv.ParseUint(fields[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			return kb / kbPerMB, true
+		case "MemTotal:":
+			kb, err := strconv.ParseUint(fields[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			totalKB, totalKnown = kb, true
+		}
+	}
+	if scanner.Err() != nil || !totalKnown {
+		return 0, false
+	}
+	return totalKB / kbPerMB, true
+}
+
+// parseCgroupLimitMB parses the content of a cgroup memory limit file
+// (v2 /sys/fs/cgroup/memory.max or v1 /sys/fs/cgroup/memory/memory.limit_in_bytes).
+// The content is a byte count, or the literal "max" (v2) / a huge sentinel (v1)
+// meaning unlimited. Returns (0, false) for unlimited, empty, or unparseable input.
+func parseCgroupLimitMB(s string) (uint64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "max" {
+		return 0, false
+	}
+	bytes, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	if bytes >= cgroupUnlimited {
+		return 0, false
+	}
+	return bytes / bytesPerMB, true
+}

--- a/config/hostmem_linux_test.go
+++ b/config/hostmem_linux_test.go
@@ -1,0 +1,191 @@
+//go:build linux
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseMeminfoMB checks the kB-to-MB conversion with exact expected values.
+// The conversion is the whole point: returning the raw kB figure would overstate
+// available memory by 1024x and defeat the memory-scaled worker default.
+func TestParseMeminfoMB(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantMB    uint64
+		wantKnown bool
+	}{
+		{
+			name:      "MemAvailable is preferred and converted from kB to MB",
+			input:     "MemTotal:       8388608 kB\nMemAvailable:   2097152 kB\n",
+			wantMB:    2048,
+			wantKnown: true,
+		},
+		{
+			name:      "MemAvailable alone",
+			input:     "MemAvailable:   1048576 kB\n",
+			wantMB:    1024,
+			wantKnown: true,
+		},
+		{
+			name:      "falls back to MemTotal when MemAvailable is absent",
+			input:     "MemTotal:       4194304 kB\nMemFree:         524288 kB\n",
+			wantMB:    4096,
+			wantKnown: true,
+		},
+		{
+			name:      "MemAvailable wins even when it appears after MemTotal",
+			input:     "MemTotal:      16777216 kB\nMemFree:        1048576 kB\nMemAvailable:   8388608 kB\n",
+			wantMB:    8192,
+			wantKnown: true,
+		},
+		{
+			name:      "neither field present is unknown",
+			input:     "MemFree:         524288 kB\nBuffers:          16384 kB\n",
+			wantKnown: false,
+		},
+		{
+			name:      "non-numeric MemAvailable with no MemTotal is unknown",
+			input:     "MemAvailable:   notanumber kB\n",
+			wantKnown: false,
+		},
+		{
+			name:      "non-numeric MemAvailable falls back to a valid MemTotal",
+			input:     "MemTotal:       2097152 kB\nMemAvailable:   notanumber kB\n",
+			wantMB:    2048,
+			wantKnown: true,
+		},
+		{
+			name:      "non-numeric MemTotal is unknown",
+			input:     "MemTotal:       garbage kB\n",
+			wantKnown: false,
+		},
+		{
+			name:      "empty input is unknown",
+			input:     "",
+			wantKnown: false,
+		},
+		{
+			name:      "realistic /proc/meminfo excerpt",
+			wantMB:    3072,
+			wantKnown: true,
+			input: `MemTotal:        8127792 kB
+MemFree:          204936 kB
+MemAvailable:    3145728 kB
+Buffers:           64712 kB
+Cached:          4102340 kB
+SwapCached:            0 kB
+Active:          2318476 kB
+Inactive:        4809912 kB
+SwapTotal:       2097152 kB
+SwapFree:        2097152 kB
+Dirty:               612 kB
+`,
+		},
+		{
+			name:      "sub-MB value floors to zero but is still known",
+			input:     "MemAvailable:        512 kB\n",
+			wantMB:    0,
+			wantKnown: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMB, gotKnown := parseMeminfoMB(strings.NewReader(tt.input))
+			if gotKnown != tt.wantKnown {
+				t.Fatalf("parseMeminfoMB() known = %v, want %v (value %d)", gotKnown, tt.wantKnown, gotMB)
+			}
+			if gotMB != tt.wantMB {
+				t.Errorf("parseMeminfoMB() = %d MB, want %d MB", gotMB, tt.wantMB)
+			}
+		})
+	}
+}
+
+// TestParseCgroupLimitMB checks the bytes-to-MB conversion and the unlimited
+// sentinels. cgroup limit files are in BYTES, not kB: treating them as kB would
+// report a 1GB container as having 1TB of headroom.
+func TestParseCgroupLimitMB(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantMB    uint64
+		wantKnown bool
+	}{
+		{
+			name:      "1GiB in bytes converts to 1024 MB",
+			input:     "1073741824",
+			wantMB:    1024,
+			wantKnown: true,
+		},
+		{
+			name:      "512MiB in bytes converts to 512 MB",
+			input:     "536870912",
+			wantMB:    512,
+			wantKnown: true,
+		},
+		{
+			name:      "trailing newline is tolerated",
+			input:     "2147483648\n",
+			wantMB:    2048,
+			wantKnown: true,
+		},
+		{
+			name:      "surrounding whitespace is tolerated",
+			input:     "  1073741824  \n",
+			wantMB:    1024,
+			wantKnown: true,
+		},
+		{
+			name:      "cgroup v2 literal max is unlimited",
+			input:     "max\n",
+			wantKnown: false,
+		},
+		{
+			name:      "cgroup v1 huge sentinel is unlimited",
+			input:     "9223372036854771712\n",
+			wantKnown: false,
+		},
+		{
+			name:      "empty input is unknown",
+			input:     "",
+			wantKnown: false,
+		},
+		{
+			name:      "whitespace-only input is unknown",
+			input:     "   \n",
+			wantKnown: false,
+		},
+		{
+			name:      "garbage is unknown",
+			input:     "not-a-number\n",
+			wantKnown: false,
+		},
+		{
+			name:      "negative value is unknown",
+			input:     "-1\n",
+			wantKnown: false,
+		},
+		{
+			name:      "sub-MB limit floors to zero but is still known",
+			input:     "1024",
+			wantMB:    0,
+			wantKnown: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMB, gotKnown := parseCgroupLimitMB(tt.input)
+			if gotKnown != tt.wantKnown {
+				t.Fatalf("parseCgroupLimitMB(%q) known = %v, want %v (value %d)", tt.input, gotKnown, tt.wantKnown, gotMB)
+			}
+			if gotMB != tt.wantMB {
+				t.Errorf("parseCgroupLimitMB(%q) = %d MB, want %d MB", tt.input, gotMB, tt.wantMB)
+			}
+		})
+	}
+}

--- a/config/hostmem_other.go
+++ b/config/hostmem_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package config
+
+// hostAvailableMemoryMB reports host memory as unknown on non-Linux platforms,
+// preserving the historical default worker count there.
+func hostAvailableMemoryMB() (uint64, bool) {
+	return 0, false
+}

--- a/internal/capture/linux/capture.go
+++ b/internal/capture/linux/capture.go
@@ -19,7 +19,6 @@ import (
 )
 
 type LinuxCapturer struct {
-	cmds      []*exec.Cmd
 	outputDir string
 }
 
@@ -82,7 +81,6 @@ func (c *LinuxCapturer) runSingleCapture(ctx context.Context, iface string, time
 	}
 
 	cmd := commandContext("tcpdump", args...)
-	c.cmds = []*exec.Cmd{cmd}
 
 	// Capture stdout and stderr (must be before Start)
 	stdoutPipe, _ := cmd.StdoutPipe()
@@ -149,11 +147,6 @@ func (c *LinuxCapturer) runMultiInterfaceCapture(ctx context.Context, interfaces
 			}
 
 			cmd := commandContext("tcpdump", args...)
-
-			// Thread-safe command tracking
-			mu.Lock()
-			c.cmds = append(c.cmds, cmd)
-			mu.Unlock()
 
 			// Capture stdout and stderr
 			stdoutPipe, _ := cmd.StdoutPipe()

--- a/internal/processor/common/format_zeek_failure_unix_test.go
+++ b/internal/processor/common/format_zeek_failure_unix_test.go
@@ -1,0 +1,186 @@
+//go:build linux || darwin
+
+package types
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// runForExitError runs a shell command that is expected to fail and returns the
+// resulting error. Using a real process guarantees a real *exec.ExitError with a
+// populated ProcessState, which is the only way to exercise the exit-status
+// decode branch in FormatZeekFailure.
+func runForExitError(t *testing.T, script string) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", script).Run()
+	if err == nil {
+		t.Fatalf("expected %q to fail, got nil error", script)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError from %q, got %T: %v", script, err, err)
+	}
+	return err
+}
+
+// signalOf pulls the terminating signal out of an error produced by a process
+// that died by signal. The signal's rendered name is platform dependent (Go
+// spells SIGABRT "aborted" on Linux and "abort trap" on Darwin), so tests must
+// derive the expected text from the same source the production formatter uses
+// rather than hardcoding either spelling.
+func signalOf(t *testing.T, err error) syscall.Signal {
+	t.Helper()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		t.Fatalf("expected syscall.WaitStatus, got %T", exitErr.Sys())
+	}
+	if !status.Signaled() {
+		t.Fatalf("expected the process to have died by signal, got %v", exitErr.ProcessState)
+	}
+	return status.Signal()
+}
+
+// TestFormatZeekFailure_ExitStatusDecode covers the exit-status decode branch
+// with errors produced by real process exits: a non-zero exit code and a death
+// by signal. Without a real *exec.ExitError, errors.As never matches and the
+// entire decode branch could be deleted with the suite still green.
+func TestFormatZeekFailure_ExitStatusDecode(t *testing.T) {
+	exitErr := runForExitError(t, "exit 3")
+	signalErr := runForExitError(t, "kill -ABRT $$")
+
+	sig := signalOf(t, signalErr)
+	if sig != syscall.SIGABRT {
+		t.Fatalf("expected the child to die of SIGABRT, got %v", sig)
+	}
+	// The full phrase the formatter must emit, signal name included, derived
+	// from the OS rather than hardcoded so it holds on Linux and Darwin alike.
+	wantSignalPhrase := "terminated by signal: " + sig.String()
+
+	tests := []struct {
+		name         string
+		err          error
+		tailContents string
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "non-zero exit code is decoded",
+			err:          exitErr,
+			tailContents: "fatal error in scripts/base/init.zeek",
+			wantContains: []string{
+				"exit code 3",
+				"zeek stderr:",
+				"fatal error in scripts/base/init.zeek",
+			},
+			wantAbsent: []string{"terminated by"},
+		},
+		{
+			name:         "death by signal is decoded",
+			err:          signalErr,
+			tailContents: "zeek crashed hard",
+			wantContains: []string{
+				wantSignalPhrase,
+				"zeek stderr:",
+				"zeek crashed hard",
+			},
+			wantAbsent: []string{"exit code"},
+		},
+		{
+			name:         "plain error formats without an exit status",
+			err:          errors.New("context deadline exceeded"),
+			tailContents: "partial output",
+			wantContains: []string{
+				"context deadline exceeded",
+				"zeek stderr:",
+				"partial output",
+			},
+			wantAbsent: []string{"exit code", "terminated by"},
+		},
+		{
+			name:         "empty tail renders the explicit empty marker",
+			err:          exitErr,
+			tailContents: "",
+			wantContains: []string{"exit code 3", "zeek stderr: <empty>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tail := NewTailBuffer(4096)
+			if tt.tailContents != "" {
+				if _, err := tail.Write([]byte(tt.tailContents)); err != nil {
+					t.Fatalf("tail.Write: %v", err)
+				}
+			}
+
+			got := FormatZeekFailure(tt.err, tail)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("FormatZeekFailure() = %q, want it to contain %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("FormatZeekFailure() = %q, want it NOT to contain %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+// TestFormatZeekFailure_SignalIsNotReportedAsExitCode pins the distinction the
+// acceptance criteria call out: a signalled process must not be described with
+// an exit code, and a clean non-zero exit must not be described as signalled.
+func TestFormatZeekFailure_SignalIsNotReportedAsExitCode(t *testing.T) {
+	signalErr := runForExitError(t, "kill -ABRT $$")
+
+	var exitErr *exec.ExitError
+	if !errors.As(signalErr, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T", signalErr)
+	}
+	if code := exitErr.ExitCode(); code >= 0 {
+		t.Fatalf("expected ExitCode() < 0 for a signalled process, got %d", code)
+	}
+
+	got := FormatZeekFailure(signalErr, nil)
+	wantSignalPhrase := "terminated by signal: " + signalOf(t, signalErr).String()
+	if !strings.Contains(got, wantSignalPhrase) {
+		t.Errorf("FormatZeekFailure() = %q, want it to contain %q", got, wantSignalPhrase)
+	}
+	if strings.Contains(got, "exit code") {
+		t.Errorf("FormatZeekFailure() = %q, want a signalled process NOT described with an exit code", got)
+	}
+	if !strings.Contains(got, "zeek stderr: <empty>") {
+		t.Errorf("FormatZeekFailure() with a nil tail = %q, want the empty-stderr marker", got)
+	}
+}
+
+// TestFormatZeekFailure_TruncatedTail verifies that a tail which dropped bytes
+// is labelled as truncated so a field engineer does not read a partial stderr
+// as the whole story.
+func TestFormatZeekFailure_TruncatedTail(t *testing.T) {
+	tail := NewTailBuffer(8)
+	if _, err := tail.Write([]byte("0123456789abcdef")); err != nil {
+		t.Fatalf("tail.Write: %v", err)
+	}
+	if !tail.Truncated() {
+		t.Fatal("expected the tail buffer to report truncation")
+	}
+
+	got := FormatZeekFailure(runForExitError(t, "exit 3"), tail)
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("FormatZeekFailure() = %q, want it to flag the truncated stderr", got)
+	}
+	if !strings.Contains(got, "89abcdef") {
+		t.Errorf("FormatZeekFailure() = %q, want it to contain the retained tail bytes", got)
+	}
+}

--- a/internal/processor/common/tailbuffer.go
+++ b/internal/processor/common/tailbuffer.go
@@ -1,0 +1,122 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ZeekStderrTailBytes bounds how much of Zeek's stderr is retained for the
+// failure log line.
+const ZeekStderrTailBytes = 64 * 1024
+
+// ZeekWaitDelay bounds how long Wait blocks after Zeek exits. Stderr is an
+// io.MultiWriter rather than an *os.File, so os/exec pipes it through a copier
+// goroutine; without a delay Wait would block forever whenever a grandchild
+// inherited the write end of that pipe and outlived Zeek, permanently parking
+// the worker goroutine. After the delay os/exec force-closes the pipes and Wait
+// returns exec.ErrWaitDelay.
+const ZeekWaitDelay = 30 * time.Second
+
+// TailBuffer is an io.Writer that retains only the last max bytes written to it.
+// It is safe for concurrent use and never reports a short write, so it can be
+// dropped into an io.MultiWriter without breaking the chain.
+type TailBuffer struct {
+	mu        sync.Mutex
+	buf       []byte
+	max       int
+	truncated bool
+}
+
+// NewTailBuffer returns a TailBuffer retaining at most max bytes. A non-positive
+// max retains nothing.
+func NewTailBuffer(max int) *TailBuffer {
+	// The backing array is allocated lazily on the first Write so a run where
+	// Zeek writes nothing to stderr costs no memory.
+	return &TailBuffer{max: max}
+}
+
+// Write records the tail of p, always reporting len(p) bytes written with a nil
+// error so io.MultiWriter does not abort with io.ErrShortWrite.
+func (t *TailBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if n == 0 {
+		return 0, nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.max <= 0 {
+		t.truncated = true
+		return n, nil
+	}
+
+	if t.buf == nil {
+		t.buf = make([]byte, 0, t.max)
+	}
+
+	if n >= t.max {
+		if n > t.max || len(t.buf) > 0 {
+			t.truncated = true
+		}
+		t.buf = append(t.buf[:0], p[n-t.max:]...)
+		return n, nil
+	}
+
+	if len(t.buf)+n > t.max {
+		t.truncated = true
+		drop := len(t.buf) + n - t.max
+		kept := copy(t.buf, t.buf[drop:])
+		t.buf = t.buf[:kept]
+	}
+	t.buf = append(t.buf, p...)
+	return n, nil
+}
+
+// String returns the retained tail.
+func (t *TailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return string(t.buf)
+}
+
+// Truncated reports whether any bytes have been discarded.
+func (t *TailBuffer) Truncated() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.truncated
+}
+
+// FormatZeekFailure builds the detail portion of the Zeek failure log line: the
+// underlying error, the decoded exit status when available, and the captured
+// stderr tail so a field engineer can read why Zeek died.
+func FormatZeekFailure(err error, tail *TailBuffer) string {
+	parts := []string{fmt.Sprintf("%v", err)}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ProcessState != nil {
+		if code := exitErr.ExitCode(); code >= 0 {
+			parts = append(parts, fmt.Sprintf("exit code %d", code))
+		} else {
+			parts = append(parts, fmt.Sprintf("terminated by %s", exitErr.ProcessState.String()))
+		}
+	}
+
+	detail := "zeek stderr: <empty>"
+	if tail != nil {
+		if s := tail.String(); s != "" {
+			if tail.Truncated() {
+				detail = fmt.Sprintf("zeek stderr (truncated, last %d bytes):\n%s", len(s), s)
+			} else {
+				detail = fmt.Sprintf("zeek stderr:\n%s", s)
+			}
+		}
+	}
+	parts = append(parts, detail)
+
+	return strings.Join(parts, " | ")
+}

--- a/internal/processor/common/tailbuffer_test.go
+++ b/internal/processor/common/tailbuffer_test.go
@@ -1,0 +1,194 @@
+package types
+
+import (
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestTailBuffer_UnderCapacity verifies that everything written is retained when
+// the total written is smaller than the buffer capacity, and Truncated stays false.
+func TestTailBuffer_UnderCapacity(t *testing.T) {
+	tb := NewTailBuffer(64)
+	n, err := tb.Write([]byte("hello world"))
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if n != len("hello world") {
+		t.Errorf("Write returned n=%d, want %d", n, len("hello world"))
+	}
+	if got := tb.String(); got != "hello world" {
+		t.Errorf("String() = %q, want %q", got, "hello world")
+	}
+	if tb.Truncated() {
+		t.Error("Truncated() = true, want false for under-capacity writes")
+	}
+}
+
+// TestTailBuffer_ExactlyAtCapacity verifies that a write filling the buffer
+// exactly is retained in full and is not reported as truncated.
+func TestTailBuffer_ExactlyAtCapacity(t *testing.T) {
+	tb := NewTailBuffer(5)
+	if _, err := tb.Write([]byte("abcde")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if got := tb.String(); got != "abcde" {
+		t.Errorf("String() = %q, want %q", got, "abcde")
+	}
+	if tb.Truncated() {
+		t.Error("Truncated() = true, want false when exactly at capacity")
+	}
+}
+
+// TestTailBuffer_OverCapacityKeepsLastBytes verifies that once more than max
+// bytes have been written the buffer retains the LAST max bytes and reports
+// itself as truncated.
+func TestTailBuffer_OverCapacityKeepsLastBytes(t *testing.T) {
+	tb := NewTailBuffer(5)
+	if _, err := tb.Write([]byte("abc")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if _, err := tb.Write([]byte("defgh")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if got := tb.String(); got != "defgh" {
+		t.Errorf("String() = %q, want last 5 bytes %q", got, "defgh")
+	}
+	if !tb.Truncated() {
+		t.Error("Truncated() = false, want true after dropping bytes")
+	}
+}
+
+// TestTailBuffer_SingleOversizedWrite verifies that a single Write larger than
+// the capacity keeps only the tail of that write.
+func TestTailBuffer_SingleOversizedWrite(t *testing.T) {
+	tb := NewTailBuffer(4)
+	payload := "0123456789"
+	n, err := tb.Write([]byte(payload))
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if n != len(payload) {
+		t.Errorf("Write returned n=%d, want %d (full length of p)", n, len(payload))
+	}
+	if got := tb.String(); got != "6789" {
+		t.Errorf("String() = %q, want %q", got, "6789")
+	}
+	if !tb.Truncated() {
+		t.Error("Truncated() = false, want true after an oversized write")
+	}
+}
+
+// TestTailBuffer_ManySmallWritesAcrossBoundary verifies the sliding-window
+// behaviour when the capacity boundary is crossed by an accumulation of small
+// writes rather than one big one.
+func TestTailBuffer_ManySmallWritesAcrossBoundary(t *testing.T) {
+	tb := NewTailBuffer(10)
+	for i := 0; i < 26; i++ {
+		b := []byte{byte('a' + i)}
+		if _, err := tb.Write(b); err != nil {
+			t.Fatalf("Write %d returned error: %v", i, err)
+		}
+	}
+	if got := tb.String(); got != "qrstuvwxyz" {
+		t.Errorf("String() = %q, want last 10 bytes %q", got, "qrstuvwxyz")
+	}
+	if !tb.Truncated() {
+		t.Error("Truncated() = false, want true")
+	}
+}
+
+// TestTailBuffer_WriteContractIsMultiWriterSafe verifies the io.Writer contract
+// that makes TailBuffer safe as a member of an io.MultiWriter: Write must always
+// report len(p) bytes written with a nil error, even when it discards bytes.
+// io.MultiWriter aborts with io.ErrShortWrite if any writer under-reports.
+func TestTailBuffer_WriteContractIsMultiWriterSafe(t *testing.T) {
+	tb := NewTailBuffer(4)
+	var sink strings.Builder
+	mw := io.MultiWriter(&sink, tb)
+
+	payload := "the quick brown fox"
+	n, err := mw.Write([]byte(payload))
+	if err != nil {
+		t.Fatalf("MultiWriter Write returned error: %v", err)
+	}
+	if n != len(payload) {
+		t.Errorf("MultiWriter Write returned n=%d, want %d", n, len(payload))
+	}
+	if sink.String() != payload {
+		t.Errorf("passthrough writer got %q, want %q", sink.String(), payload)
+	}
+	if got := tb.String(); got != " fox" {
+		t.Errorf("tail String() = %q, want %q", got, " fox")
+	}
+}
+
+// TestTailBuffer_ZeroAndNegativeCapacity verifies that a non-positive capacity
+// is safe: it retains nothing, never panics, and still honours the io.Writer
+// contract of reporting len(p).
+func TestTailBuffer_ZeroAndNegativeCapacity(t *testing.T) {
+	for _, max := range []int{0, -1, -100} {
+		tb := NewTailBuffer(max)
+		n, err := tb.Write([]byte("some zeek stderr"))
+		if err != nil {
+			t.Errorf("max=%d: Write returned error: %v", max, err)
+		}
+		if n != len("some zeek stderr") {
+			t.Errorf("max=%d: Write returned n=%d, want %d", max, n, len("some zeek stderr"))
+		}
+		if got := tb.String(); got != "" {
+			t.Errorf("max=%d: String() = %q, want empty", max, got)
+		}
+	}
+}
+
+// TestTailBuffer_EmptyWrite verifies a zero-length write is a no-op that does
+// not mark the buffer truncated.
+func TestTailBuffer_EmptyWrite(t *testing.T) {
+	tb := NewTailBuffer(8)
+	n, err := tb.Write(nil)
+	if err != nil {
+		t.Fatalf("Write(nil) returned error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Write(nil) returned n=%d, want 0", n)
+	}
+	if tb.Truncated() {
+		t.Error("Truncated() = true after empty write, want false")
+	}
+	if got := tb.String(); got != "" {
+		t.Errorf("String() = %q, want empty", got)
+	}
+}
+
+// TestTailBuffer_ConcurrentWrites exercises TailBuffer from multiple goroutines
+// so that `go test -race` flags any missing synchronization. Zeek's stdout and
+// stderr are written from separate goroutines by os/exec, so this is the real
+// usage pattern, not a hypothetical.
+func TestTailBuffer_ConcurrentWrites(t *testing.T) {
+	tb := NewTailBuffer(32)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 64; j++ {
+				if _, err := tb.Write([]byte("zeek stderr line\n")); err != nil {
+					t.Errorf("concurrent Write returned error: %v", err)
+					return
+				}
+				_ = tb.String()
+				_ = tb.Truncated()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := len(tb.String()); got > 32 {
+		t.Errorf("String() length = %d, want <= 32", got)
+	}
+	if !tb.Truncated() {
+		t.Error("Truncated() = false after far more than 32 bytes written, want true")
+	}
+}

--- a/internal/processor/linux/processor.go
+++ b/internal/processor/linux/processor.go
@@ -4,6 +4,7 @@ package linux
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -32,6 +33,8 @@ type FS interface {
 
 type Cmd interface {
 	Run() error
+	SetStdout(w io.Writer)
+	SetStderr(w io.Writer)
 }
 
 type CmdRunner interface {
@@ -50,12 +53,16 @@ func (realFS) Rename(oldpath, newpath string) error         { return os.Rename(o
 
 type realCmd struct{ cmd *exec.Cmd }
 
-func (r *realCmd) Run() error { return r.cmd.Run() }
+func (r *realCmd) Run() error            { return r.cmd.Run() }
+func (r *realCmd) SetStdout(w io.Writer) { r.cmd.Stdout = w }
+func (r *realCmd) SetStderr(w io.Writer) { r.cmd.Stderr = w }
 
 type realCmdRunner struct{}
 
 func (realCmdRunner) Command(name string, arg ...string) Cmd {
-	return &realCmd{cmd: exec.Command(name, arg...)}
+	cmd := exec.Command(name, arg...)
+	cmd.WaitDelay = types.ZeekWaitDelay
+	return &realCmd{cmd: cmd}
 }
 
 // Processor implements the Processor interface for Linux
@@ -109,13 +116,11 @@ func (p *Processor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (typ
 
 	log.Printf("[processor] Running Zeek: %s %v", p.zeekPath, zeekArgs)
 	cmd := p.cmdRunner.Command(p.zeekPath, zeekArgs...)
-	cmdStdout, ok := cmd.(*realCmd)
-	if ok {
-		cmdStdout.cmd.Stdout = os.Stdout
-		cmdStdout.cmd.Stderr = os.Stderr
-	}
+	stderrTail := types.NewTailBuffer(types.ZeekStderrTailBytes)
+	cmd.SetStdout(os.Stdout)
+	cmd.SetStderr(io.MultiWriter(os.Stderr, stderrTail))
 	if err := cmd.Run(); err != nil {
-		log.Printf("[processor] Zeek execution failed: %v", err)
+		log.Printf("[processor] Zeek execution failed: %s", types.FormatZeekFailure(err, stderrTail))
 		return types.ProcessedData{}, fmt.Errorf("zeek failed: %w", err)
 	}
 	log.Printf("[processor] Zeek execution completed successfully.")

--- a/internal/processor/linux/processor_test.go
+++ b/internal/processor/linux/processor_test.go
@@ -3,7 +3,11 @@
 package linux
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,9 +96,14 @@ func (r *capturingCmdRunner) Command(name string, arg ...string) Cmd {
 	return stubCmd{}
 }
 
+// stubCmd aborts immediately. It satisfies the full Cmd interface (including the
+// stdout/stderr seams used for Zeek failure capture) but discards both streams:
+// this test only cares about the args handed to Command.
 type stubCmd struct{}
 
-func (stubCmd) Run() error { return fmt.Errorf("stub: skipping real zeek execution") }
+func (stubCmd) Run() error            { return fmt.Errorf("stub: skipping real zeek execution") }
+func (stubCmd) SetStdout(w io.Writer) {}
+func (stubCmd) SetStderr(w io.Writer) {}
 
 func argsContain(args []string, substr string) bool {
 	for _, a := range args {
@@ -127,3 +136,176 @@ func TestProcessPCAP_JA3JA4ScriptMaterialized(t *testing.T) {
 }
 
 // TODO: Add more granular unit tests with mocks for Zeek and file conversion.
+
+// fakeCmd is a test double for Cmd that records the writers it was handed,
+// emits a canned stderr payload when Run is called, and returns a canned error.
+type fakeCmd struct {
+	stderrOut string // written to the stderr writer during Run
+	runErr    error
+
+	stdout io.Writer
+	stderr io.Writer
+
+	runCalled          bool
+	setStdoutCalled    bool
+	setStderrCalled    bool
+	stdoutSetBeforeRun bool
+	stderrSetBeforeRun bool
+}
+
+func (f *fakeCmd) SetStdout(w io.Writer) {
+	f.setStdoutCalled = true
+	f.stdoutSetBeforeRun = !f.runCalled
+	f.stdout = w
+}
+
+func (f *fakeCmd) SetStderr(w io.Writer) {
+	f.setStderrCalled = true
+	f.stderrSetBeforeRun = !f.runCalled
+	f.stderr = w
+}
+
+func (f *fakeCmd) Run() error {
+	f.runCalled = true
+	if f.stderrOut != "" && f.stderr != nil {
+		if _, err := io.WriteString(f.stderr, f.stderrOut); err != nil {
+			return err
+		}
+	}
+	return f.runErr
+}
+
+// fakeCmdRunner hands out a single pre-configured fakeCmd.
+type fakeCmdRunner struct {
+	cmd *fakeCmd
+}
+
+func (r *fakeCmdRunner) Command(name string, arg ...string) Cmd { return r.cmd }
+
+// captureLogs redirects the standard logger into a buffer for the duration of
+// the test and restores it afterwards.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	return &buf
+}
+
+// runProcessPCAPWithFake wires the processor to the given fake command and runs
+// ProcessPCAP against a throwaway run directory. It returns the error from
+// ProcessPCAP and the captured log output.
+func runProcessPCAPWithFake(t *testing.T, fc *fakeCmd) (string, error) {
+	t.Helper()
+	buf := captureLogs(t)
+	pcapPath := filepath.Join(t.TempDir(), "capture.pcap")
+	p := NewProcessorWithDeps(realFS{}, &fakeCmdRunner{cmd: fc}, "/opt/zeek/bin/zeek")
+	_, err := p.ProcessPCAP(pcapPath, types.ProcessOptions{SamplingPercentage: 100})
+	return buf.String(), err
+}
+
+// TestProcessPCAP_ZeekNonZeroExitSurfacesStderr verifies that when Zeek exits
+// non-zero, the stderr it produced (the only place the real reason appears) is
+// surfaced in the sensor log rather than silently discarded.
+func TestProcessPCAP_ZeekNonZeroExitSurfacesStderr(t *testing.T) {
+	const zeekStderr = "fatal error: problem with trace file /tmp/capture.pcap (No such file or directory)\n"
+	fc := &fakeCmd{stderrOut: zeekStderr, runErr: errors.New("exit status 1")}
+
+	logs, err := runProcessPCAPWithFake(t, fc)
+	if err == nil {
+		t.Fatal("ProcessPCAP returned nil error, want a zeek failure error")
+	}
+	if !strings.Contains(err.Error(), "zeek failed") {
+		t.Errorf("error = %q, want it to wrap %q", err.Error(), "zeek failed")
+	}
+	if !strings.Contains(logs, "[processor] Zeek execution failed:") {
+		t.Errorf("log output missing the failure line, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "problem with trace file") {
+		t.Errorf("log output does not contain the captured Zeek stderr, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "No such file or directory") {
+		t.Errorf("log output does not contain the Zeek stderr detail, got:\n%s", logs)
+	}
+}
+
+// TestProcessPCAP_ZeekAbortSurfacesStderr covers the signal/abort shape, where
+// Zeek dies on an uncaught exception and the exit error alone says nothing
+// useful.
+func TestProcessPCAP_ZeekAbortSurfacesStderr(t *testing.T) {
+	const zeekStderr = "terminating with uncaught exception of type std::bad_alloc: std::bad_alloc\n"
+	fc := &fakeCmd{stderrOut: zeekStderr, runErr: errors.New("signal: aborted")}
+
+	logs, err := runProcessPCAPWithFake(t, fc)
+	if err == nil {
+		t.Fatal("ProcessPCAP returned nil error, want a zeek failure error")
+	}
+	if !strings.Contains(logs, "[processor] Zeek execution failed:") {
+		t.Errorf("log output missing the failure line, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "std::bad_alloc") {
+		t.Errorf("log output does not contain the bad_alloc stderr, got:\n%s", logs)
+	}
+}
+
+// TestProcessPCAP_ZeekFailsWithNoStderr verifies the empty-stderr path still
+// reports the failure and does not panic on an empty tail buffer.
+func TestProcessPCAP_ZeekFailsWithNoStderr(t *testing.T) {
+	fc := &fakeCmd{stderrOut: "", runErr: errors.New("exit status 2")}
+
+	logs, err := runProcessPCAPWithFake(t, fc)
+	if err == nil {
+		t.Fatal("ProcessPCAP returned nil error, want a zeek failure error")
+	}
+	if !strings.Contains(err.Error(), "zeek failed") {
+		t.Errorf("error = %q, want it to wrap %q", err.Error(), "zeek failed")
+	}
+	if !strings.Contains(logs, "[processor] Zeek execution failed:") {
+		t.Errorf("log output missing the failure line, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "exit status 2") {
+		t.Errorf("log output missing the underlying error, got:\n%s", logs)
+	}
+}
+
+// TestProcessPCAP_ZeekSuccessDoesNotLogFailure verifies that stderr noise from a
+// successful Zeek run is not reported as a failure. ProcessPCAP still returns an
+// error from later stages against a throwaway run dir, so this asserts only on
+// the absence of the failure line.
+func TestProcessPCAP_ZeekSuccessDoesNotLogFailure(t *testing.T) {
+	fc := &fakeCmd{stderrOut: "warning: no packet filter, listening on all traffic\n", runErr: nil}
+
+	logs, _ := runProcessPCAPWithFake(t, fc)
+	if strings.Contains(logs, "Zeek execution failed") {
+		t.Errorf("failure line logged for a successful Zeek run, got:\n%s", logs)
+	}
+}
+
+// TestProcessPCAP_SetsStdoutAndStderrBeforeRun verifies the processor attaches
+// non-nil output writers to the command before starting it, which is what makes
+// the stderr capture possible at all.
+func TestProcessPCAP_SetsStdoutAndStderrBeforeRun(t *testing.T) {
+	fc := &fakeCmd{stderrOut: "some output\n", runErr: errors.New("exit status 1")}
+
+	if _, _ = runProcessPCAPWithFake(t, fc); !fc.runCalled {
+		t.Fatal("Run was never called on the fake command")
+	}
+	if !fc.setStdoutCalled {
+		t.Error("SetStdout was never called")
+	}
+	if !fc.setStderrCalled {
+		t.Error("SetStderr was never called")
+	}
+	if !fc.stdoutSetBeforeRun {
+		t.Error("SetStdout was called after Run, want before")
+	}
+	if !fc.stderrSetBeforeRun {
+		t.Error("SetStderr was called after Run, want before")
+	}
+	if fc.stdout == nil {
+		t.Error("SetStdout was handed a nil writer")
+	}
+	if fc.stderr == nil {
+		t.Error("SetStderr was handed a nil writer")
+	}
+}

--- a/internal/processor/windows/processor.go
+++ b/internal/processor/windows/processor.go
@@ -5,6 +5,7 @@ package windows
 import (
 	types "EnigmaNetz/Enigma-Go-Sensor/internal/processor/common"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -85,11 +86,13 @@ func (p *Processor) ProcessPCAP(pcapPath string, opts types.ProcessOptions) (typ
 
 	cmd := p.execCmd("bin/zeek.exe", zeekArgs...)
 	cmd.Dir = zeekBaseDir
+	stderrTail := types.NewTailBuffer(types.ZeekStderrTailBytes)
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = io.MultiWriter(os.Stderr, stderrTail)
 	cmd.Env = append(os.Environ(), "ZEEKPATH="+zeekShareAbs)
+	cmd.WaitDelay = types.ZeekWaitDelay
 	if err := cmd.Run(); err != nil {
-		log.Printf("[processor] Zeek execution failed: %v", err)
+		log.Printf("[processor] Zeek execution failed: %s", types.FormatZeekFailure(err, stderrTail))
 		return types.ProcessedData{}, fmt.Errorf("zeek failed: %w", err)
 	}
 	log.Printf("[processor] Zeek execution completed successfully.")

--- a/internal/selfmetrics/selfmetrics.go
+++ b/internal/selfmetrics/selfmetrics.go
@@ -1,0 +1,103 @@
+// Package selfmetrics samples the sensor's own resource usage so growth in
+// memory, file descriptors or on-disk Zeek output is visible in the log.
+package selfmetrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Stats is a point-in-time sample of the sensor process's own resource usage.
+type Stats struct {
+	RSSBytes       uint64 // 0 when unavailable
+	OpenFDs        int    // -1 when unavailable
+	ThreadsOS      int    // -1 when unavailable
+	Goroutines     int
+	HeapAllocBytes uint64
+	ZeekOutDirs    int // -1 when not measured
+}
+
+// Sample collects a Stats snapshot. outputDir may be empty, in which case the
+// Zeek output directory count is not measured.
+func Sample(outputDir string) Stats {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	rss, threads := readRSSAndThreads()
+
+	return Stats{
+		RSSBytes:       rss,
+		OpenFDs:        countOpenFDs(),
+		ThreadsOS:      threads,
+		Goroutines:     runtime.NumGoroutine(),
+		HeapAllocBytes: mem.HeapAlloc,
+		ZeekOutDirs:    countZeekOutDirs(outputDir),
+	}
+}
+
+// countZeekOutDirs counts directories named zeek_out_* directly under dir.
+// Returns -1 when dir is empty or cannot be read.
+func countZeekOutDirs(dir string) int {
+	if dir == "" {
+		return -1
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return -1
+	}
+	count := 0
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "zeek_out_") {
+			count++
+		}
+	}
+	return count
+}
+
+// LogLine renders the sample as a single log line, showing "n/a" for any value
+// that could not be measured on this platform.
+func (s Stats) LogLine() string {
+	rss := "n/a"
+	if s.RSSBytes > 0 {
+		rss = fmt.Sprintf("%d", s.RSSBytes)
+	}
+	return fmt.Sprintf("[selfmetrics] rss_bytes=%s open_fds=%s os_threads=%s goroutines=%d heap_alloc_bytes=%d zeek_out_dirs=%s",
+		rss,
+		renderCount(s.OpenFDs),
+		renderCount(s.ThreadsOS),
+		s.Goroutines,
+		s.HeapAllocBytes,
+		renderCount(s.ZeekOutDirs),
+	)
+}
+
+// renderCount renders a count, mapping the -1 unavailable sentinel to "n/a".
+func renderCount(v int) string {
+	if v < 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%d", v)
+}
+
+// StartLogger logs a sample immediately and then once per interval until ctx is
+// done. It is a pure observer and returns as soon as ctx is cancelled.
+func StartLogger(ctx context.Context, interval time.Duration, outputDir string) {
+	log.Print(Sample(outputDir).LogLine())
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			log.Print(Sample(outputDir).LogLine())
+		}
+	}
+}

--- a/internal/selfmetrics/selfmetrics_linux.go
+++ b/internal/selfmetrics/selfmetrics_linux.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package selfmetrics
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// readRSSAndThreads reads resident set size (bytes) and OS thread count from
+// /proc/self/status. Unavailable values come back as 0 and -1 respectively.
+func readRSSAndThreads() (uint64, int) {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0, -1
+	}
+	return parseProcStatus(data)
+}
+
+// parseProcStatus extracts the resident set size in BYTES (VmRSS, reported in kB)
+// and the OS thread count (Threads) from /proc/<pid>/status content. Whichever
+// field is absent or unparseable comes back as its unavailable sentinel:
+// rssBytes is 0 when unknown, threads is -1 when unknown.
+func parseProcStatus(data []byte) (rssBytes uint64, threads int) {
+	rssBytes = 0
+	threads = -1
+
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case strings.HasPrefix(line, "VmRSS:"):
+			// VmRSS is reported in kB, e.g. "VmRSS:      12345 kB".
+			fields := strings.Fields(strings.TrimPrefix(line, "VmRSS:"))
+			if len(fields) > 0 {
+				if kb, err := strconv.ParseUint(fields[0], 10, 64); err == nil {
+					rssBytes = kb * 1024
+				}
+			}
+		case strings.HasPrefix(line, "Threads:"):
+			if n, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "Threads:"))); err == nil {
+				threads = n
+			}
+		}
+	}
+
+	return rssBytes, threads
+}
+
+// countOpenFDs counts entries in /proc/self/fd. The count includes the fd held
+// open by this read itself; that is consistent run to run, so it is not
+// corrected for. Returns -1 when unavailable.
+func countOpenFDs() int {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return -1
+	}
+	return len(entries)
+}

--- a/internal/selfmetrics/selfmetrics_linux_test.go
+++ b/internal/selfmetrics/selfmetrics_linux_test.go
@@ -1,0 +1,124 @@
+//go:build linux
+
+package selfmetrics
+
+import "testing"
+
+// TestParseProcStatus pins the kB-to-bytes conversion of VmRSS with exact
+// expected byte counts. Dropping the * 1024 would under-report resident memory
+// by 1024x, which is exactly the kind of units bug a "greater than zero"
+// assertion would sail straight past.
+func TestParseProcStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantRSS     uint64
+		wantThreads int
+	}{
+		{
+			name: "realistic /proc/self/status excerpt",
+			input: `Name:	sensor
+Umask:	0022
+State:	S (sleeping)
+Tgid:	1234
+Pid:	1234
+PPid:	1
+VmPeak:	  1234567 kB
+VmSize:	  1234000 kB
+VmRSS:	    12345 kB
+RssAnon:	     9000 kB
+Threads:	7
+SigQ:	0/31234
+`,
+			wantRSS:     12345 * 1024,
+			wantThreads: 7,
+		},
+		{
+			name:        "minimal pair",
+			input:       "VmRSS:\t2048 kB\nThreads:\t1\n",
+			wantRSS:     2048 * 1024,
+			wantThreads: 1,
+		},
+		{
+			name:        "VmRSS missing leaves the zero sentinel",
+			input:       "Name:\tsensor\nThreads:\t4\n",
+			wantRSS:     0,
+			wantThreads: 4,
+		},
+		{
+			name:        "Threads missing leaves the -1 sentinel",
+			input:       "VmRSS:\t512 kB\n",
+			wantRSS:     512 * 1024,
+			wantThreads: -1,
+		},
+		{
+			name:        "malformed VmRSS value falls back to the sentinel",
+			input:       "VmRSS:\tnotanumber kB\nThreads:\t3\n",
+			wantRSS:     0,
+			wantThreads: 3,
+		},
+		{
+			name:        "malformed Threads value falls back to the sentinel",
+			input:       "VmRSS:\t4096 kB\nThreads:\tmany\n",
+			wantRSS:     4096 * 1024,
+			wantThreads: -1,
+		},
+		{
+			name:        "both malformed falls back to both sentinels",
+			input:       "VmRSS:\t\nThreads:\t\n",
+			wantRSS:     0,
+			wantThreads: -1,
+		},
+		{
+			name:        "empty input yields both sentinels",
+			input:       "",
+			wantRSS:     0,
+			wantThreads: -1,
+		},
+		{
+			name:        "zero RSS is reported as zero bytes",
+			input:       "VmRSS:\t0 kB\nThreads:\t2\n",
+			wantRSS:     0,
+			wantThreads: 2,
+		},
+		{
+			name:        "large RSS does not overflow",
+			input:       "VmRSS:\t8388608 kB\nThreads:\t12\n",
+			wantRSS:     8388608 * 1024,
+			wantThreads: 12,
+		},
+		{
+			name:        "no trailing newline on the final field",
+			input:       "VmRSS:\t1000 kB\nThreads:\t9",
+			wantRSS:     1000 * 1024,
+			wantThreads: 9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRSS, gotThreads := parseProcStatus([]byte(tt.input))
+			if gotRSS != tt.wantRSS {
+				t.Errorf("parseProcStatus() rssBytes = %d, want %d", gotRSS, tt.wantRSS)
+			}
+			if gotThreads != tt.wantThreads {
+				t.Errorf("parseProcStatus() threads = %d, want %d", gotThreads, tt.wantThreads)
+			}
+		})
+	}
+}
+
+// TestParseProcStatus_RSSIsBytesNotKB states the units contract on its own so a
+// regression to kB fails with an unambiguous message rather than hiding inside
+// a table row.
+func TestParseProcStatus_RSSIsBytesNotKB(t *testing.T) {
+	const kB = 65432
+	rss, _ := parseProcStatus([]byte("VmRSS:\t65432 kB\nThreads:\t1\n"))
+
+	if rss == kB {
+		t.Fatalf("parseProcStatus() returned %d, which is the raw kB value; it must return bytes", rss)
+	}
+	if want := uint64(kB) * 1024; rss != want {
+		t.Errorf("parseProcStatus() rssBytes = %d, want %d", rss, want)
+	}
+}

--- a/internal/selfmetrics/selfmetrics_other.go
+++ b/internal/selfmetrics/selfmetrics_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package selfmetrics
+
+// readRSSAndThreads reports the unavailable sentinels on non-Linux platforms.
+func readRSSAndThreads() (uint64, int) {
+	return 0, -1
+}
+
+// countOpenFDs reports the unavailable sentinel on non-Linux platforms.
+func countOpenFDs() int {
+	return -1
+}

--- a/internal/selfmetrics/selfmetrics_test.go
+++ b/internal/selfmetrics/selfmetrics_test.go
@@ -1,0 +1,205 @@
+package selfmetrics
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sink retains allocations so the compiler cannot elide them.
+var sink [][]byte
+
+func TestSampleNoOutputDir(t *testing.T) {
+	s := Sample("")
+
+	if s.Goroutines <= 0 {
+		t.Errorf("Goroutines = %d, want > 0", s.Goroutines)
+	}
+	if s.HeapAllocBytes == 0 {
+		t.Error("HeapAllocBytes = 0, want > 0")
+	}
+	if s.ZeekOutDirs != -1 {
+		t.Errorf("ZeekOutDirs = %d, want -1 when outputDir is empty", s.ZeekOutDirs)
+	}
+
+	if runtime.GOOS == "linux" {
+		if s.RSSBytes == 0 {
+			t.Error("RSSBytes = 0 on linux, want > 0")
+		}
+		if s.OpenFDs <= 0 {
+			t.Errorf("OpenFDs = %d on linux, want > 0", s.OpenFDs)
+		}
+		if s.ThreadsOS <= 0 {
+			t.Errorf("ThreadsOS = %d on linux, want > 0", s.ThreadsOS)
+		}
+	}
+}
+
+func TestSampleCountsZeekOutDirsOnly(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"zeek_out_A", "zeek_out_B", "zeek_out_C", "other"} {
+		if err := os.Mkdir(filepath.Join(dir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+	// decoy: matching prefix but a regular file, not a directory
+	if err := os.WriteFile(filepath.Join(dir, "zeek_out_notadir"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write decoy file: %v", err)
+	}
+
+	if got := Sample(dir).ZeekOutDirs; got != 3 {
+		t.Errorf("ZeekOutDirs = %d, want 3", got)
+	}
+}
+
+func TestSampleMissingOutputDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does", "not", "exist")
+
+	if got := Sample(missing).ZeekOutDirs; got != -1 {
+		t.Errorf("ZeekOutDirs = %d for missing dir, want -1", got)
+	}
+}
+
+func TestLogLinePopulated(t *testing.T) {
+	s := Stats{
+		RSSBytes:       123456789,
+		OpenFDs:        42,
+		ThreadsOS:      7,
+		Goroutines:     19,
+		HeapAllocBytes: 987654321,
+		ZeekOutDirs:    3,
+	}
+
+	line := s.LogLine()
+	if !strings.Contains(line, "[selfmetrics] ") {
+		t.Errorf("LogLine() = %q, want it to contain the %q prefix", line, "[selfmetrics] ")
+	}
+	for _, want := range []string{"123456789", "42", "7", "19", "987654321", "3"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("LogLine() = %q, missing value %q", line, want)
+		}
+	}
+	if strings.Contains(line, "n/a") {
+		t.Errorf("LogLine() = %q, should not render n/a when all values are available", line)
+	}
+}
+
+func TestLogLineUnavailableValues(t *testing.T) {
+	s := Stats{
+		RSSBytes:       0,
+		OpenFDs:        -1,
+		ThreadsOS:      -1,
+		Goroutines:     11,
+		HeapAllocBytes: 2048,
+		ZeekOutDirs:    -1,
+	}
+
+	line := s.LogLine()
+	if !strings.Contains(line, "[selfmetrics] ") {
+		t.Errorf("LogLine() = %q, want it to contain the %q prefix", line, "[selfmetrics] ")
+	}
+	if strings.Count(line, "n/a") != 4 {
+		t.Errorf("LogLine() = %q, want 4 n/a renderings (rss, fds, threads, zeek dirs)", line)
+	}
+	if strings.Contains(line, "-1") {
+		t.Errorf("LogLine() = %q, should render n/a rather than the -1 sentinel", line)
+	}
+	for _, want := range []string{"11", "2048"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("LogLine() = %q, missing available value %q", line, want)
+		}
+	}
+}
+
+func TestSampleObservesHeapGrowth(t *testing.T) {
+	sink = nil
+	before := Sample("")
+
+	sink = make([][]byte, 0, 20000)
+	for i := 0; i < 20000; i++ {
+		sink = append(sink, make([]byte, 512))
+	}
+
+	after := Sample("")
+	if after.HeapAllocBytes <= before.HeapAllocBytes {
+		t.Errorf("HeapAllocBytes did not grow: before=%d after=%d", before.HeapAllocBytes, after.HeapAllocBytes)
+	}
+
+	runtime.KeepAlive(sink)
+	sink = nil
+}
+
+// lockedBuffer serializes writes from the logger goroutine against test reads.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestStartLoggerLogsPeriodicallyAndReturnsOnCancel(t *testing.T) {
+	var buf lockedBuffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartLogger(ctx, 10*time.Millisecond, "")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartLogger did not return within 2s of context cancellation")
+	}
+
+	if n := strings.Count(buf.String(), "[selfmetrics] "); n < 2 {
+		t.Errorf("logged %d [selfmetrics] lines, want at least 2", n)
+	}
+}
+
+func TestStartLoggerLogsImmediatelyWhenContextAlreadyCancelled(t *testing.T) {
+	var buf lockedBuffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartLogger(ctx, time.Hour, "")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartLogger did not return promptly for an already-cancelled context")
+	}
+
+	if n := strings.Count(buf.String(), "[selfmetrics] "); n < 1 {
+		t.Errorf("logged %d [selfmetrics] lines, want at least 1 immediate sample", n)
+	}
+}

--- a/internal/sensor/sensor.go
+++ b/internal/sensor/sensor.go
@@ -20,11 +20,15 @@ import (
 	"EnigmaNetz/Enigma-Go-Sensor/internal/pcapingest"
 	types "EnigmaNetz/Enigma-Go-Sensor/internal/processor/common"
 	"EnigmaNetz/Enigma-Go-Sensor/internal/processor/common/zeekscripts"
+	"EnigmaNetz/Enigma-Go-Sensor/internal/selfmetrics"
 	"archive/zip"
 	"runtime"
 )
 
 var ErrAPIGone = errors.New("sensor received 410 Gone from API and should stop")
+
+// selfMetricsInterval is how often the sensor logs its own resource usage.
+const selfMetricsInterval = 5 * time.Minute
 
 // Capturer abstracts the capture logic
 // (You can use mockgen for tests)
@@ -276,8 +280,9 @@ func RunSensor(ctx context.Context, cfg *config.Config, capturer Capturer, proce
 
 	maxWorkers := cfg.Capture.MaxProcessingWorkers
 	if maxWorkers < 1 {
-		maxWorkers = 10
+		maxWorkers = 1
 	}
+	log.Printf("[sensor] Processing workers: %d", maxWorkers)
 	pcapQueue := make(chan string, maxWorkers)
 	var wg sync.WaitGroup
 
@@ -350,6 +355,12 @@ func RunSensor(ctx context.Context, cfg *config.Config, capturer Capturer, proce
 		wg.Add(1)
 		go worker(i)
 	}
+
+	// Log the sensor's own resource usage periodically. This is a pure observer,
+	// so it is deliberately not tracked by wg (which is waited on at shutdown).
+	metricsCtx, cancelMetrics := context.WithCancel(ctx)
+	defer cancelMetrics()
+	go selfmetrics.StartLogger(metricsCtx, selfMetricsInterval, cfg.Capture.OutputDir)
 
 	// Start PCAP ingest watcher if enabled
 	if cfg.PcapIngest.Enabled {


### PR DESCRIPTION
Refs #65. Target 1.9.4.

**The root-cause leak is NOT confirmed fixed by this PR.** A full code audit of the per-iteration hot path did not find a Go-side leak large enough to explain the ~4.75-day constant-uptime OOM in the default configuration. This PR delivers the observability needed to diagnose it, the one real accumulation that was found, and the worker-pool safety change. Details below.

## Ask 1: Zeek stderr on failure (done)

Zeek's stderr went straight to the sensor's own stderr, so a failed run left only `exit status 1` in the log. Zeek stderr is now mirrored to `os.Stderr` and captured into a bounded 64KB tail buffer; on failure the log line carries the tail plus the decoded exit code or terminating signal. So `bad_alloc`, reporter fatals and analyzer errors are now readable straight from the sensor log. Mirrored on the Windows processor, which had the byte-identical defect.

One consequence worth flagging: tee-ing stderr means it is no longer an `*os.File`, so `os/exec` now pipes it through a copier goroutine, and `Wait` would block forever if a grandchild inherited the pipe and outlived Zeek. A `WaitDelay` is set to convert that into a logged error rather than a permanently parked worker.

## Ask 2: hot-path leak audit (one fix, no definitive root cause)

**Fixed:** `LinuxCapturer.cmds` grew without bound. `runSingleCapture` reassigns the slice, but `runMultiInterfaceCapture` appended to it, and the capturer lives for the whole process. The field was write-only (never read anywhere in the repo), so it is deleted rather than reset. Note this only fires when `capture.interface` lists 2+ interfaces, and it is roughly 1-1.5KB per interface per iteration, so on its own it is an order of magnitude too small to explain the observed OOM. Presenting it as the cause would overstate the evidence.

**Affirmatively ruled out**, each checked against the code: per-iteration gRPC dials (the connection is dialed once at startup); unclosed or un-drained tcpdump pipes (`Wait` closes the parent ends, and `Start`'s deferred cleanup covers the error path); scanner goroutines outliving an iteration; un-reaped children or zombies (every `Start` has a matching `Wait`); worker-pool goroutine growth (workers start once, the loop body contains no `go` statement); unbounded queue growth (fixed capacity with a non-blocking drop arm); per-iteration tickers, timers or contexts; leaked `*os.File` handles in the processing path; upload buffer and chunk temp files; and per-iteration state on the uploader and processor structs.

**Leading unproven hypothesis, needs on-box data:** cleanup of `zeek_out_*` directories. When `retention_hours` is absent from the live config it falls back to `log_retention_days * 24`, i.e. 7 days, so a config missing that key accumulates one run directory per iteration for 7 days before the first eviction ever runs, and the observed death is at ~4.75 days. That is normally just disk, but it becomes memory pressure if `output_dir` is on tmpfs or if a cgroup limit is what is actually being hit. Worth checking on an affected host: `findmnt -T <output_dir>`, the effective `retention_hours` in the live config, and whether the OOM victim is the sensor process or the cgroup.

## Ask 3: periodic self-metrics (done)

New `internal/selfmetrics` package logs a `[selfmetrics]` line every 5 minutes with RSS, open fd count, OS threads, goroutines, Go heap allocation, and the count of `zeek_out_*` directories in the capture output dir. The last gauge is deliberately included beyond the literal ask because it is what falsifies or confirms the hypothesis above without a site visit. Limitation documented in DEVELOPMENT.md: it counts only `capture.output_dir`, not the optional pcap-ingest watch dir.

## Ask 4: worker pool on low-RAM hosts (done)

The default `max_processing_workers` (previously a flat 10) now scales to available memory at roughly 768MB per worker, clamped to 1-10. Memory is taken as the **minimum of `/proc/meminfo` and any cgroup limit** - inside a container `/proc/meminfo` reports the host, so a 1GB container on a 64GB host would otherwise still have picked 10 and been OOM-killed exactly as before. Explicit values are still honored and still range-validated 1-20.

Scope note, flagged by review and deliberately kept: when an operator has explicitly pinned a value higher than memory supports, a one-time startup warning is logged. Strictly the AC covers only the default, but an operator who pinned 10 gets no benefit from this change at all, and the warning is the only thing that would tell them why they are still being OOM-killed.

## Verification

- 435 tests pass under `go test -race ./...`; `go vet`, `go build` and `gofmt` clean for linux, windows and darwin.
- Tests were written before the implementation, in a separate pass, and the four unit-conversion and decode branches that review found mutation-survivable were re-checked by actually applying the mutation: dropping the kB-to-bytes conversion in the RSS parser, the kB-to-MB and bytes-to-MB conversions in the memory parser, and neutering the exit/signal decode all now fail the suite.
- `config.example.json` deliberately does **not** carry a `max_processing_workers` key, so a fresh install falls through to the memory-scaled default.
