### PR TITLE
Bundle collect-logs as a tar.gz on Linux and fail loudly on hollow bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Package logs and config for support:
 ./enigma-sensor collect-logs
 ```
 
-This creates `enigma-logs-YYYYMMDD-HHMMSS.zip` with logs, captures, config, version, and system info.
+This creates `enigma-logs-YYYYMMDD-HHMMSS.tar.gz` on Linux and macOS, or `enigma-logs-YYYYMMDD-HHMMSS.zip` on Windows, with logs, captures, config, version, and system info.
 
 ---
 

--- a/cmd/enigma-sensor/main.go
+++ b/cmd/enigma-sensor/main.go
@@ -31,7 +31,7 @@ Usage: enigma-sensor [collect-logs] [--version|-v] [--help|-h]
 Runs a network capture and processing session using config.json.
 
 Options:
-  collect-logs    Package logs, captures, config, and diagnostics into a zip archive for support
+  collect-logs    Package logs, captures, config, and diagnostics into an archive for support
   --version, -v   Print version and exit
   --help, -h      Show this help message and exit
 
@@ -45,7 +45,7 @@ Example:
     Runs a single capture and processing session using config.json.
 
   enigma-sensor collect-logs
-    Packages logs, captures, config, and diagnostics into a zip archive for support.
+    Packages logs, captures, config, and diagnostics into an archive for support.
 
   enigma-sensor --help
     Shows this help message.
@@ -65,13 +65,13 @@ func main() {
 			fmt.Println(version.Version)
 			return
 		case "collect-logs":
-			zipName := fmt.Sprintf("enigma-logs-%s.zip", time.Now().Format("20060102-150405"))
-			err := collect_logs.CollectLogs(zipName)
+			outName := fmt.Sprintf("enigma-logs-%s%s", time.Now().Format("20060102-150405"), collect_logs.ArchiveExt)
+			size, err := collect_logs.CollectLogs(outName)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to collect logs: %v\n", err)
 				os.Exit(1)
 			}
-			fmt.Printf("Created %s with logs, config, and diagnostics.\n", zipName)
+			fmt.Printf("Created %s (%d bytes) with logs, config, and diagnostics.\n", outName, size)
 			return
 		}
 	}

--- a/internal/collect_logs/collectlogs.go
+++ b/internal/collect_logs/collectlogs.go
@@ -2,10 +2,8 @@ package collect_logs
 
 import (
 	"EnigmaNetz/Enigma-Go-Sensor/internal/version"
-	"archive/zip"
 	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,86 +11,116 @@ import (
 	"strings"
 )
 
-// CollectLogs creates a zip archive with logs, captures, config, version, and system info for diagnostics.
-// zipName is the output file name (e.g., "enigma-logs-YYYYMMDD-HHMMSS.zip").
-func CollectLogs(zipName string) error {
-	zipFile, err := os.Create(zipName)
-	if err != nil {
-		return fmt.Errorf("failed to create zip: %w", err)
-	}
-	defer zipFile.Close()
+// archiveBlob is generated content to be added to the archive under Name.
+type archiveBlob struct {
+	Name    string
+	Content string
+}
 
-	zipWriter := zip.NewWriter(zipFile)
-	defer zipWriter.Close()
+// minArchiveBytes is the floor below which a written archive is treated as
+// hollow rather than valid.
+const minArchiveBytes = 256
 
-	// Add all files in logs/
+// writeArchive is the platform-specific archive writer. It is a variable so
+// tests can substitute a failing or degenerate implementation.
+var writeArchive = writeArchiveDefault
+
+// CollectLogs creates an archive with logs, captures, config, version, and system info for diagnostics.
+// outName is the output file name (e.g., "enigma-logs-YYYYMMDD-HHMMSS" + ArchiveExt).
+// It returns the size of the written archive in bytes. Reporting the result to
+// the operator is the caller's job.
+func CollectLogs(outName string) (size int64, retErr error) {
+	// A failed run must not leave a partial or hollow archive behind for an
+	// operator to pick up and ship to support.
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(outName)
+		}
+	}()
+
+	// files holds the paths of on-disk files to add to the archive, which are
+	// also used unchanged as the path inside the archive.
+	var files []string
+	var blobs []archiveBlob
+
+	// gatheredBytes counts only real diagnostic content gathered from disk.
+	// The generated version.txt and system-info.txt blobs are deliberately
+	// excluded: they are always present and would mask an otherwise empty
+	// bundle.
+	var gatheredBytes int64
+
+	// Add all regular files directly in logs/
 	logDir := "logs"
-	logFiles, err := os.ReadDir(logDir)
-	if err == nil { // logs/ may not exist
+	if logFiles, err := os.ReadDir(logDir); err == nil { // logs/ may not exist
 		for _, entry := range logFiles {
 			if entry.IsDir() {
 				continue
 			}
 			path := filepath.Join(logDir, entry.Name())
-			if err := addFileToZip(zipWriter, path); err != nil {
-				// Non-fatal, just skip
+			if info, err := entry.Info(); err == nil {
+				gatheredBytes += info.Size()
 			}
+			files = append(files, path)
 		}
 	}
 
-	// Recursively add all files in captures/
-	capturesDir := "captures"
-	_ = addDirToZip(zipWriter, capturesDir) // Non-fatal
-
-	// Add config.json if present
-	if _, err := os.Stat("config.json"); err == nil {
-		_ = addFileToZip(zipWriter, "config.json") // Non-fatal
-	}
-
-	// Add version.txt
-	_ = addStringToZip(zipWriter, "version.txt", version.Version+"\n")
-
-	// Add system-info.txt
-	sysInfo := getSystemInfo()
-	_ = addStringToZip(zipWriter, "system-info.txt", sysInfo)
-
-	return nil
-}
-
-func addFileToZip(zipWriter *zip.Writer, filename string) error {
-	file, err := os.Open(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	w, err := zipWriter.Create(filename)
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(w, file)
-	return err
-}
-
-func addStringToZip(zipWriter *zip.Writer, filename, content string) error {
-	w, err := zipWriter.Create(filename)
-	if err != nil {
-		return err
-	}
-	_, err = w.Write([]byte(content))
-	return err
-}
-
-func addDirToZip(zipWriter *zip.Writer, dir string) error {
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	// Recursively add all files in captures/ (non-fatal if absent)
+	_ = filepath.WalkDir("captures", func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
-		return addFileToZip(zipWriter, path)
+		if info, err := d.Info(); err == nil {
+			gatheredBytes += info.Size()
+		}
+		files = append(files, path)
+		return nil
 	})
+
+	// Add config.json if present
+	if info, err := os.Stat("config.json"); err == nil {
+		gatheredBytes += info.Size()
+		files = append(files, "config.json")
+	}
+
+	if gatheredBytes == 0 {
+		wd, wdErr := os.Getwd()
+		if wdErr != nil {
+			wd = "the current working directory"
+		}
+		return 0, fmt.Errorf("no diagnostic content found in %s: logs/ and captures/ are empty or absent and config.json is missing; run collect-logs from the sensor's working directory (the one holding logs/, captures/, and config.json)", wd)
+	}
+
+	blobs = append(blobs,
+		archiveBlob{Name: "version.txt", Content: version.Version + "\n"},
+		archiveBlob{Name: "system-info.txt", Content: getSystemInfo()},
+	)
+
+	written, err := writeArchive(outName, files, blobs)
+	if err != nil {
+		return 0, fmt.Errorf("failed to write archive %s: %w", outName, err)
+	}
+
+	// gatheredBytes is measured from stat before archiving, so it does not
+	// prove anything actually landed in the bundle: every gathered file can
+	// still fail to open (root-owned logs/ collected as a non-root user). The
+	// count of entries genuinely written is the guard that catches that.
+	if len(files) > 0 && written == 0 {
+		return 0, fmt.Errorf("archive %s contains no diagnostic files: all %d gathered files failed to be archived (check permissions on logs/, captures/, and config.json)", outName, len(files))
+	}
+
+	info, err := os.Stat(outName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to stat archive %s after writing: %w", outName, err)
+	}
+
+	if info.Size() < minArchiveBytes {
+		return 0, fmt.Errorf("archive %s is implausibly small: %d bytes", outName, info.Size())
+	}
+
+	return info.Size(), nil
 }
 
 func getSystemInfo() string {

--- a/internal/collect_logs/collectlogs_test.go
+++ b/internal/collect_logs/collectlogs_test.go
@@ -1,137 +1,202 @@
 package collect_logs
 
 import (
-	"archive/zip"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
 )
 
-func TestCollectLogs_CreatesZipWithExpectedFiles(t *testing.T) {
+// seedDiagnosticContent writes a real log file into the current working
+// directory so CollectLogs has actual diagnostic content to gather.
+func seedDiagnosticContent(t *testing.T) {
+	t.Helper()
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	if err := os.WriteFile("logs/test.log", []byte(strings.Repeat("x", 300)), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+}
+
+// TestCollectLogs_NoDiagnosticContent_ReturnsError verifies that running
+// CollectLogs from a directory with no logs/, no captures/, and no
+// config.json fails loudly instead of emitting a hollow archive that contains
+// only the generated version.txt and system-info.txt blobs.
+func TestCollectLogs_NoDiagnosticContent_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
-	cwd, _ := os.Getwd()
-	defer os.Chdir(cwd)
-	os.Chdir(tmpDir)
+	t.Chdir(tmpDir)
 
-	// Setup: create logs/, captures/, config.json
-	os.Mkdir("logs", 0755)
-	os.WriteFile("logs/test.log", []byte("logdata"), 0644)
-	os.MkdirAll("captures/session1", 0755)
-	os.WriteFile("captures/session1/cap.pcap", []byte("pcapdata"), 0644)
-	os.WriteFile("config.json", []byte(`{"foo": "bar"}`), 0644)
-
-	zipName := "test-logs.zip"
-	err := CollectLogs(zipName)
-	if err != nil {
-		t.Fatalf("CollectLogs failed: %v", err)
+	_, err := CollectLogs("test-logs" + ArchiveExt)
+	if err == nil {
+		t.Fatal("expected CollectLogs to return an error when no diagnostic content exists, got nil")
 	}
-
-	// Check zip file exists
-	if _, err := os.Stat(zipName); err != nil {
-		t.Fatalf("Zip file not created: %v", err)
+	if !strings.Contains(err.Error(), "no diagnostic content found") {
+		t.Errorf("expected error to mention missing diagnostic content, got: %v", err)
 	}
-
-	// Open and check contents
-	r, err := zip.OpenReader(zipName)
-	if err != nil {
-		t.Fatalf("Failed to open zip: %v", err)
-	}
-	defer r.Close()
-
-	files := map[string]bool{}
-	for _, f := range r.File {
-		normalized := strings.ReplaceAll(f.Name, "\\", "/")
-		files[normalized] = true
-	}
-
-	// Should include these files
-	for _, want := range []string{
-		"logs/test.log", "captures/session1/cap.pcap", "config.json", "version.txt", "system-info.txt",
-	} {
-		if !files[want] {
-			t.Errorf("Expected %s in zip, not found", want)
+	for _, want := range []string{"logs/", "captures/", "config.json"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to name %q, got: %v", want, err)
 		}
 	}
 }
 
-func TestCollectLogs_MissingDirsAreHandled(t *testing.T) {
+// TestCollectLogs_ArchiveStepFailure_ReturnsError verifies that CollectLogs
+// surfaces an error (rather than silently succeeding) when the underlying
+// archive-writing step fails.
+func TestCollectLogs_ArchiveStepFailure_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
-	cwd, _ := os.Getwd()
-	defer os.Chdir(cwd)
-	os.Chdir(tmpDir)
+	t.Chdir(tmpDir)
+	seedDiagnosticContent(t)
 
-	// Only create config.json
-	os.WriteFile("config.json", []byte(`{"foo": "bar"}`), 0644)
-
-	zipName := "test-logs-missing.zip"
-	err := CollectLogs(zipName)
-	if err != nil {
-		t.Fatalf("CollectLogs failed: %v", err)
+	original := writeArchive
+	t.Cleanup(func() { writeArchive = original })
+	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+		return 0, fmt.Errorf("simulated archive write failure")
 	}
 
-	// Check zip file exists
-	if _, err := os.Stat(zipName); err != nil {
-		t.Fatalf("Zip file not created: %v", err)
+	_, err := CollectLogs("test-logs" + ArchiveExt)
+	if err == nil {
+		t.Fatal("expected CollectLogs to return an error when writeArchive fails, got nil")
 	}
-
-	// Open and check contents
-	r, err := zip.OpenReader(zipName)
-	if err != nil {
-		t.Fatalf("Failed to open zip: %v", err)
-	}
-	defer r.Close()
-
-	var foundConfig, foundVersion, foundSysinfo bool
-	for _, f := range r.File {
-		normalized := strings.ReplaceAll(f.Name, "\\", "/")
-		if normalized == "config.json" {
-			foundConfig = true
-		}
-		if normalized == "version.txt" {
-			foundVersion = true
-		}
-		if normalized == "system-info.txt" {
-			foundSysinfo = true
-		}
-	}
-	if !foundConfig || !foundVersion || !foundSysinfo {
-		t.Errorf("Expected config.json, version.txt, and system-info.txt in zip (got: %v)", r.File)
+	if !strings.Contains(err.Error(), "simulated archive write failure") {
+		t.Errorf("expected error to surface the underlying failure, got: %v", err)
 	}
 }
 
-func TestCollectLogs_EmptyDirs(t *testing.T) {
+// TestCollectLogs_ImplausiblySmallArchive_ReturnsError verifies that
+// CollectLogs rejects an archive that is suspiciously small even though the
+// write step reported success.
+func TestCollectLogs_ImplausiblySmallArchive_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
-	cwd, _ := os.Getwd()
-	defer os.Chdir(cwd)
-	os.Chdir(tmpDir)
+	t.Chdir(tmpDir)
+	seedDiagnosticContent(t)
 
-	os.Mkdir("logs", 0755)
-	os.Mkdir("captures", 0755)
+	original := writeArchive
+	t.Cleanup(func() { writeArchive = original })
+	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+		// Simulate a writer that "succeeds" but produces an implausibly
+		// small file (10 bytes).
+		return len(files), os.WriteFile(outName, []byte("tinydata!!"), 0644)
+	}
 
-	zipName := "test-logs-empty.zip"
-	err := CollectLogs(zipName)
+	outName := "test-logs" + ArchiveExt
+	_, err := CollectLogs(outName)
+	if err == nil {
+		t.Fatal("expected CollectLogs to return an error for an implausibly small archive, got nil")
+	}
+	if !strings.Contains(err.Error(), "small") {
+		t.Errorf("expected error to mention 'small', got: %v", err)
+	}
+}
+
+// TestCollectLogs_MissingArchive_ReturnsError verifies that CollectLogs
+// returns an error when the archive step reports success but never actually
+// wrote the output file.
+func TestCollectLogs_MissingArchive_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	seedDiagnosticContent(t)
+
+	original := writeArchive
+	t.Cleanup(func() { writeArchive = original })
+	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+		return len(files), nil // reports success but writes nothing
+	}
+
+	outName := "test-logs" + ArchiveExt
+	_, err := CollectLogs(outName)
+	if err == nil {
+		t.Fatal("expected CollectLogs to return an error when the archive file is missing, got nil")
+	}
+}
+
+// TestCollectLogs_Success_ReturnsArchiveSize verifies that a successful run
+// returns the byte size of the archive it wrote, so the caller can report it.
+func TestCollectLogs_Success_ReturnsArchiveSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	// Pad well past the minimum-size floor so the real archiver produces a
+	// plausible archive.
+	filler := strings.Repeat("x", 300)
+	if err := os.WriteFile("logs/test.log", []byte(filler), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+
+	outName := "test-logs" + ArchiveExt
+
+	size, err := CollectLogs(outName)
 	if err != nil {
 		t.Fatalf("CollectLogs failed: %v", err)
 	}
 
-	// Open and check contents
-	r, err := zip.OpenReader(zipName)
-	if err != nil {
-		t.Fatalf("Failed to open zip: %v", err)
+	if size == 0 {
+		t.Error("expected CollectLogs to return a non-zero archive size, got 0")
 	}
-	defer r.Close()
 
-	var foundVersion, foundSysinfo bool
-	for _, f := range r.File {
-		normalized := strings.ReplaceAll(f.Name, "\\", "/")
-		if normalized == "version.txt" {
-			foundVersion = true
-		}
-		if normalized == "system-info.txt" {
-			foundSysinfo = true
-		}
+	info, err := os.Stat(outName)
+	if err != nil {
+		t.Fatalf("expected archive to exist: %v", err)
 	}
-	if !foundVersion || !foundSysinfo {
-		t.Errorf("Expected version.txt and system-info.txt in zip (got: %v)", r.File)
+	if size != info.Size() {
+		t.Errorf("expected returned size %d to match the archive on disk (%d bytes)", size, info.Size())
+	}
+}
+
+// TestCollectLogs_NoFilesArchived_ReturnsError verifies that a bundle holding
+// only the generated blobs fails even when the written file clears the
+// minimum-size floor. Files are gathered per stat but none can be archived
+// (the root-owned logs/ collected as a non-root user case), so the entry count
+// reported by the archive writer is the only guard that can fire.
+func TestCollectLogs_NoFilesArchived_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	seedDiagnosticContent(t)
+
+	original := writeArchive
+	t.Cleanup(func() { writeArchive = original })
+	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+		// Writes a plausibly sized file, but archived none of the gathered
+		// source files.
+		return 0, os.WriteFile(outName, []byte(strings.Repeat("h", 512)), 0644)
+	}
+
+	outName := "test-logs" + ArchiveExt
+	_, err := CollectLogs(outName)
+	if err == nil {
+		t.Fatal("expected CollectLogs to return an error when no gathered file was archived, got nil")
+	}
+	if !strings.Contains(err.Error(), "no diagnostic files") {
+		t.Errorf("expected error to mention that no diagnostic files were archived, got: %v", err)
+	}
+}
+
+// TestCollectLogs_FailedRun_RemovesArchive verifies that a run that fails after
+// the output file was created does not leave a misleading archive on disk.
+func TestCollectLogs_FailedRun_RemovesArchive(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	seedDiagnosticContent(t)
+
+	original := writeArchive
+	t.Cleanup(func() { writeArchive = original })
+	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+		if err := os.WriteFile(outName, []byte(strings.Repeat("h", 512)), 0644); err != nil {
+			return 0, err
+		}
+		return 0, fmt.Errorf("simulated archive write failure")
+	}
+
+	outName := "test-logs" + ArchiveExt
+	if _, err := CollectLogs(outName); err == nil {
+		t.Fatal("expected CollectLogs to return an error, got nil")
+	}
+
+	if _, err := os.Stat(outName); !os.IsNotExist(err) {
+		t.Errorf("expected the partial archive %s to be removed, stat err: %v", outName, err)
 	}
 }

--- a/internal/collect_logs/collectlogs_unix.go
+++ b/internal/collect_logs/collectlogs_unix.go
@@ -1,0 +1,156 @@
+//go:build !windows
+
+package collect_logs
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+)
+
+// ArchiveExt is the archive extension used on non-Windows platforms.
+const ArchiveExt = ".tar.gz"
+
+// writeArchiveDefault writes a gzip-compressed tar archive containing the
+// given on-disk files and generated blobs. It returns the number of on-disk
+// source files actually written into the archive; the generated blobs are not
+// counted.
+func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (int, error) {
+	out, err := os.Create(outName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create archive file %s: %w", outName, err)
+	}
+
+	gzWriter := gzip.NewWriter(out)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	written := 0
+	writeErr := func() error {
+		for _, path := range files {
+			if err := addFileToTar(tarWriter, path); err != nil {
+				// Non-fatal: a source file that cannot be archived is skipped.
+				// addFileToTar leaves the tar stream well-formed in that case.
+				fmt.Fprintf(os.Stderr, "warning: skipped %s: %v\n", path, err)
+				continue
+			}
+			written++
+		}
+		for _, blob := range blobs {
+			if err := addBlobToTar(tarWriter, blob); err != nil {
+				return fmt.Errorf("failed to add %s to archive: %w", blob.Name, err)
+			}
+		}
+		return nil
+	}()
+
+	if writeErr != nil {
+		_ = tarWriter.Close()
+		_ = gzWriter.Close()
+		_ = out.Close()
+		return written, writeErr
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		_ = gzWriter.Close()
+		_ = out.Close()
+		return written, fmt.Errorf("failed to close tar writer for %s: %w", outName, err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		_ = out.Close()
+		return written, fmt.Errorf("failed to close gzip writer for %s: %w", outName, err)
+	}
+	if err := out.Close(); err != nil {
+		return written, fmt.Errorf("failed to close archive file %s: %w", outName, err)
+	}
+	return written, nil
+}
+
+// addFileToTar writes one on-disk file into the tar stream. The tar writer
+// pre-declares the entry size, so exactly hdr.Size bytes must be written or the
+// writer latches a sticky error that would poison every later entry. Anything
+// that could produce a short or long copy is therefore handled here: non-regular
+// files are rejected before the header is written, a file that shrank mid-copy
+// is zero-padded, and a file that grew is truncated to the declared size.
+func addFileToTar(tarWriter *tar.Writer, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", path)
+	}
+
+	hdr := &tar.Header{
+		Name:     path,
+		Mode:     0644,
+		Size:     info.Size(),
+		ModTime:  info.ModTime(),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tarWriter.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	n, copyErr := io.CopyN(tarWriter, f, hdr.Size)
+	if copyErr != nil && copyErr != io.EOF {
+		// The entry is already open in the stream. Pad it out so the archive
+		// stays well-formed, then report the failure so the caller can skip it.
+		if padErr := padTarEntry(tarWriter, hdr.Size-n); padErr != nil {
+			return fmt.Errorf("failed to pad truncated entry %s: %w", path, padErr)
+		}
+		return copyErr
+	}
+	if n < hdr.Size {
+		// The file shrank between stat and copy. Pad the remainder with zeros
+		// so the declared size is honoured.
+		if err := padTarEntry(tarWriter, hdr.Size-n); err != nil {
+			return fmt.Errorf("failed to pad shrunken entry %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// padTarEntry writes n zero bytes into the current tar entry.
+func padTarEntry(tarWriter *tar.Writer, n int64) error {
+	if n <= 0 {
+		return nil
+	}
+	if _, err := io.CopyN(tarWriter, zeroReader{}, n); err != nil {
+		return err
+	}
+	return nil
+}
+
+// zeroReader is an infinite source of zero bytes.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func addBlobToTar(tarWriter *tar.Writer, blob archiveBlob) error {
+	hdr := &tar.Header{
+		Name:     blob.Name,
+		Mode:     0644,
+		Size:     int64(len(blob.Content)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tarWriter.WriteHeader(hdr); err != nil {
+		return err
+	}
+	if _, err := tarWriter.Write([]byte(blob.Content)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/collect_logs/collectlogs_unix_test.go
+++ b/internal/collect_logs/collectlogs_unix_test.go
@@ -1,0 +1,223 @@
+//go:build !windows
+
+package collect_logs
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCollectLogs_Unix_ArchiveContainsExpectedFiles verifies that on
+// non-Windows platforms CollectLogs produces a .tar.gz archive containing
+// all expected members, and that file content round-trips byte-for-byte.
+func TestCollectLogs_Unix_ArchiveContainsExpectedFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	logContent := "logdata-" + strings.Repeat("a", 300)
+	if err := os.WriteFile("logs/test.log", []byte(logContent), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+	if err := os.MkdirAll("captures/session1", 0755); err != nil {
+		t.Fatalf("failed to create captures dir: %v", err)
+	}
+	if err := os.WriteFile("captures/session1/cap.pcap", []byte("pcapdata-"+strings.Repeat("p", 300)), 0644); err != nil {
+		t.Fatalf("failed to write pcap file: %v", err)
+	}
+	if err := os.WriteFile("config.json", []byte(`{"foo": "`+strings.Repeat("b", 300)+`"}`), 0644); err != nil {
+		t.Fatalf("failed to write config.json: %v", err)
+	}
+
+	outName := "test-logs.tar.gz"
+	if _, err := CollectLogs(outName); err != nil {
+		t.Fatalf("CollectLogs failed: %v", err)
+	}
+
+	info, err := os.Stat(outName)
+	if err != nil {
+		t.Fatalf("archive not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("expected archive to be non-empty")
+	}
+	if info.Size() <= 256 {
+		t.Errorf("expected archive larger than 256 bytes, got %d", info.Size())
+	}
+
+	f, err := os.Open(outName)
+	if err != nil {
+		t.Fatalf("failed to open archive: %v", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("failed to open gzip reader: %v", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	members := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed to read tar entry: %v", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		buf := make([]byte, hdr.Size)
+		if _, err := io.ReadFull(tr, buf); err != nil {
+			t.Fatalf("failed to read member %s: %v", hdr.Name, err)
+		}
+		members[hdr.Name] = buf
+	}
+
+	for _, want := range []string{
+		"logs/test.log", "captures/session1/cap.pcap", "config.json", "version.txt", "system-info.txt",
+	} {
+		if _, ok := members[want]; !ok {
+			names := make([]string, 0, len(members))
+			for k := range members {
+				names = append(names, k)
+			}
+			t.Errorf("expected %s in archive, not found (members: %v)", want, names)
+		}
+	}
+
+	if got := string(members["logs/test.log"]); got != logContent {
+		t.Errorf("logs/test.log content mismatch: got %q, want %q", got, logContent)
+	}
+}
+
+// TestCollectLogs_Unix_MissingDirsAreHandled verifies that when logs/ and
+// captures/ are absent, CollectLogs still succeeds and includes config.json,
+// version.txt, and system-info.txt.
+func TestCollectLogs_Unix_MissingDirsAreHandled(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	if err := os.WriteFile("config.json", []byte(`{"foo": "`+strings.Repeat("c", 300)+`"}`), 0644); err != nil {
+		t.Fatalf("failed to write config.json: %v", err)
+	}
+
+	outName := "test-logs-missing.tar.gz"
+	if _, err := CollectLogs(outName); err != nil {
+		t.Fatalf("CollectLogs failed: %v", err)
+	}
+
+	f, err := os.Open(outName)
+	if err != nil {
+		t.Fatalf("failed to open archive: %v", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("failed to open gzip reader: %v", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	found := map[string]bool{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed to read tar entry: %v", err)
+		}
+		found[hdr.Name] = true
+	}
+
+	for _, want := range []string{"config.json", "version.txt", "system-info.txt"} {
+		if !found[want] {
+			t.Errorf("expected %s in archive, not found", want)
+		}
+	}
+}
+
+// TestCollectLogs_Unix_NonRegularCaptureEntry_DoesNotCorruptArchive verifies
+// that a non-regular entry under captures/ (here a symlink pointing at a
+// directory) is skipped without poisoning the tar stream. Declaring a header
+// size and then writing fewer bytes latches a sticky "missed writing N bytes"
+// error on tar.Writer, which would fail every later entry and the whole run.
+func TestCollectLogs_Unix_NonRegularCaptureEntry_DoesNotCorruptArchive(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	logContent := "logdata-" + strings.Repeat("a", 300)
+	if err := os.WriteFile("logs/enigma.log", []byte(logContent), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+	if err := os.MkdirAll("captures/session1", 0755); err != nil {
+		t.Fatalf("failed to create captures dir: %v", err)
+	}
+	// A symlink to a directory: filepath.Walk does not follow it, so it is
+	// enumerated as a file, but os.Open plus Stat resolve it to a directory.
+	if err := os.Symlink(filepath.Join(tmpDir, "captures", "session1"), filepath.Join("captures", "link")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	outName := "test-logs.tar.gz"
+	if _, err := CollectLogs(outName); err != nil {
+		t.Fatalf("CollectLogs failed on a non-regular captures entry: %v", err)
+	}
+
+	f, err := os.Open(outName)
+	if err != nil {
+		t.Fatalf("failed to open archive: %v", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("failed to open gzip reader: %v", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	members := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("archive is corrupt, failed to read tar entry: %v", err)
+		}
+		buf := make([]byte, hdr.Size)
+		if _, err := io.ReadFull(tr, buf); err != nil {
+			t.Fatalf("failed to read member %s: %v", hdr.Name, err)
+		}
+		members[hdr.Name] = buf
+	}
+
+	for _, want := range []string{"logs/enigma.log", "version.txt", "system-info.txt"} {
+		if _, ok := members[want]; !ok {
+			names := make([]string, 0, len(members))
+			for k := range members {
+				names = append(names, k)
+			}
+			t.Errorf("expected %s in archive, not found (members: %v)", want, names)
+		}
+	}
+	if got := string(members["logs/enigma.log"]); got != logContent {
+		t.Errorf("logs/enigma.log content mismatch: got %q, want %q", got, logContent)
+	}
+}

--- a/internal/collect_logs/collectlogs_windows.go
+++ b/internal/collect_logs/collectlogs_windows.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package collect_logs
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+)
+
+// ArchiveExt is the archive extension used on Windows.
+const ArchiveExt = ".zip"
+
+// writeArchiveDefault writes a zip archive containing the given on-disk files
+// and generated blobs. It returns the number of on-disk source files actually
+// written into the archive; the generated blobs are not counted.
+func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (int, error) {
+	out, err := os.Create(outName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create archive file %s: %w", outName, err)
+	}
+
+	zipWriter := zip.NewWriter(out)
+
+	written := 0
+	writeErr := func() error {
+		for _, path := range files {
+			if err := addFileToZip(zipWriter, path); err != nil {
+				// Non-fatal: a source file that cannot be archived is skipped.
+				fmt.Fprintf(os.Stderr, "warning: skipped %s: %v\n", path, err)
+				continue
+			}
+			written++
+		}
+		for _, blob := range blobs {
+			if err := addBlobToZip(zipWriter, blob); err != nil {
+				return fmt.Errorf("failed to add %s to archive: %w", blob.Name, err)
+			}
+		}
+		return nil
+	}()
+
+	if writeErr != nil {
+		_ = zipWriter.Close()
+		_ = out.Close()
+		return written, writeErr
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		_ = out.Close()
+		return written, fmt.Errorf("failed to close zip writer for %s: %w", outName, err)
+	}
+	if err := out.Close(); err != nil {
+		return written, fmt.Errorf("failed to close archive file %s: %w", outName, err)
+	}
+	return written, nil
+}
+
+func addFileToZip(zipWriter *zip.Writer, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file: %s", path)
+	}
+
+	w, err := zipWriter.Create(path)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, f)
+	return err
+}
+
+func addBlobToZip(zipWriter *zip.Writer, blob archiveBlob) error {
+	w, err := zipWriter.Create(blob.Name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write([]byte(blob.Content))
+	return err
+}

--- a/internal/collect_logs/collectlogs_windows_test.go
+++ b/internal/collect_logs/collectlogs_windows_test.go
@@ -1,0 +1,140 @@
+//go:build windows
+
+package collect_logs
+
+import (
+	"archive/zip"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCollectLogs_Windows_CreatesZipWithExpectedFiles ports the original
+// zip-based coverage: CollectLogs on Windows still produces a .zip archive
+// with the expected members.
+func TestCollectLogs_Windows_CreatesZipWithExpectedFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	// Setup: create logs/, captures/, config.json
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	if err := os.WriteFile("logs/test.log", []byte("logdata-"+strings.Repeat("a", 300)), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+	if err := os.MkdirAll("captures/session1", 0755); err != nil {
+		t.Fatalf("failed to create captures dir: %v", err)
+	}
+	if err := os.WriteFile("captures/session1/cap.pcap", []byte("pcapdata-"+strings.Repeat("p", 300)), 0644); err != nil {
+		t.Fatalf("failed to write pcap file: %v", err)
+	}
+	if err := os.WriteFile("config.json", []byte(`{"foo": "`+strings.Repeat("b", 300)+`"}`), 0644); err != nil {
+		t.Fatalf("failed to write config.json: %v", err)
+	}
+
+	zipName := "test-logs.zip"
+	_, err := CollectLogs(zipName)
+	if err != nil {
+		t.Fatalf("CollectLogs failed: %v", err)
+	}
+
+	// Check zip file exists
+	if _, err := os.Stat(zipName); err != nil {
+		t.Fatalf("Zip file not created: %v", err)
+	}
+
+	// Open and check contents
+	r, err := zip.OpenReader(zipName)
+	if err != nil {
+		t.Fatalf("Failed to open zip: %v", err)
+	}
+	defer r.Close()
+
+	files := map[string]bool{}
+	for _, f := range r.File {
+		normalized := strings.ReplaceAll(f.Name, "\\", "/")
+		files[normalized] = true
+	}
+
+	// Should include these files
+	for _, want := range []string{
+		"logs/test.log", "captures/session1/cap.pcap", "config.json", "version.txt", "system-info.txt",
+	} {
+		if !files[want] {
+			t.Errorf("Expected %s in zip, not found", want)
+		}
+	}
+}
+
+// TestCollectLogs_Windows_MissingDirsAreHandled ports the original coverage
+// for the case where only config.json is present.
+func TestCollectLogs_Windows_MissingDirsAreHandled(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	// Only create config.json
+	if err := os.WriteFile("config.json", []byte(`{"foo": "`+strings.Repeat("c", 300)+`"}`), 0644); err != nil {
+		t.Fatalf("failed to write config.json: %v", err)
+	}
+
+	zipName := "test-logs-missing.zip"
+	_, err := CollectLogs(zipName)
+	if err != nil {
+		t.Fatalf("CollectLogs failed: %v", err)
+	}
+
+	// Check zip file exists
+	if _, err := os.Stat(zipName); err != nil {
+		t.Fatalf("Zip file not created: %v", err)
+	}
+
+	// Open and check contents
+	r, err := zip.OpenReader(zipName)
+	if err != nil {
+		t.Fatalf("Failed to open zip: %v", err)
+	}
+	defer r.Close()
+
+	var foundConfig, foundVersion, foundSysinfo bool
+	for _, f := range r.File {
+		normalized := strings.ReplaceAll(f.Name, "\\", "/")
+		if normalized == "config.json" {
+			foundConfig = true
+		}
+		if normalized == "version.txt" {
+			foundVersion = true
+		}
+		if normalized == "system-info.txt" {
+			foundSysinfo = true
+		}
+	}
+	if !foundConfig || !foundVersion || !foundSysinfo {
+		t.Errorf("Expected config.json, version.txt, and system-info.txt in zip (got: %v)", r.File)
+	}
+}
+
+// TestCollectLogs_Windows_EmptyDirs_ReturnsError verifies that the
+// no-diagnostic-content check applies on Windows too: empty logs/ and
+// captures/ with no config.json must fail rather than emit a hollow zip
+// holding only the generated version.txt and system-info.txt blobs.
+func TestCollectLogs_Windows_EmptyDirs_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	if err := os.Mkdir("captures", 0755); err != nil {
+		t.Fatalf("failed to create captures dir: %v", err)
+	}
+
+	zipName := "test-logs-empty.zip"
+	_, err := CollectLogs(zipName)
+	if err == nil {
+		t.Fatal("expected CollectLogs to return an error when no diagnostic content exists, got nil")
+	}
+	if !strings.Contains(err.Error(), "no diagnostic content found") {
+		t.Errorf("expected error to mention missing diagnostic content, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #67

## What changed

`collect-logs` now writes its diagnostic bundle as a `.tar.gz` on Linux and macOS using stdlib `archive/tar` + `compress/gzip`. Windows is unchanged and still produces a `.zip`. Neither path shells out to an external archive tool.

The command no longer exits 0 on a useless bundle. It now exits non-zero with an actionable error when nothing was gathered, or when files were found but none could actually be archived (permissions). Partial archives are removed on failure, each skipped source file gets a stderr warning, and the final bundle path and size are printed on success.

## Correction to the issue's premise

The issue states that `collect-logs` shells out to the `zip` binary. It does not: the previous code used Go's `archive/zip` package, so a missing `zip` binary was never the cause.

The real cause of the hollow ~500-byte bundle is that `logs/`, `captures/`, and `config.json` are resolved **relative to the current working directory**. An operator running `collect-logs` from anywhere other than the sensor's working directory gathers nothing, and the two always-present generated files (`version.txt`, `system-info.txt`) make the result look like a successful archive.

Fixing that path resolution is out of scope here. This PR converts that silent failure into a loud one, and the error message points the operator at the actual problem:

```
$ cd /tmp/empty && enigma-sensor collect-logs
Failed to collect logs: no diagnostic content found in /tmp/empty: logs/ and
captures/ are empty or absent and config.json is missing; run collect-logs from
the sensor's working directory (the one holding logs/, captures/, and config.json)
$ echo $?
1
```

**Recommended follow-up:** resolve the collected paths from the installed sensor's data directory rather than the cwd, so the command works from anywhere.

## Notes

- A size floor alone was not sufficient: the hollow bundle measures ~360 bytes, and a legitimate minimal bundle ~400, so the guard is based on whether any source file was actually written into the archive. The size floor is kept as a secondary check against a truncated write.
- The fail-loudly behavior applies on Windows too, since that ask was not platform-scoped. Only the archive format change is Linux-only.
- A pre-existing test asserting that an empty run succeeds was inverted, since it encoded the bug being fixed.