### PR TITLE
Version bump to v1.9.4

### DIFF
--- a/installer/debian/DEBIAN/control
+++ b/installer/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: enigma-sensor
-Version: 1.9.3
+Version: 1.9.4
 Section: utils
 Priority: optional
 Architecture: amd64

--- a/installer/windows/enigma-sensor-installer.iss
+++ b/installer/windows/enigma-sensor-installer.iss
@@ -3,7 +3,7 @@
 
 [Setup]
 AppName=Enigma Sensor
-AppVersion=1.9.3
+AppVersion=1.9.4
 DefaultDirName={autopf}\EnigmaSensor
 DefaultGroupName=Enigma Sensor
 OutputBaseFilename=enigma-sensor-installer

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current release version of the Enigma Go Sensor.
-const Version = "v1.9.3"
+const Version = "v1.9.4"


### PR DESCRIPTION
Bumps the sensor version to v1.9.4 across the Go version constant, the Debian control file, and the Windows installer script.

Patch release covering the changes merged since v1.9.3: bundled Zeek in the Linux release, embedded Zeek scripts in the binary, JA3/JA4 fingerprint emission, excluded-subnet flow filtering, DHCP option 55 capture, private-CA gRPC TLS support, collect-logs tarball bundling, and an explicit refusal on Ubuntu 20.04 and older.