### PR TITLE
Resolve collect-logs sources from the packaged install layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Package logs and config for support:
 ./enigma-sensor collect-logs
 ```
 
-This creates `enigma-logs-YYYYMMDD-HHMMSS.tar.gz` on Linux and macOS, or `enigma-logs-YYYYMMDD-HHMMSS.zip` on Windows, with logs, captures, config, version, and system info.
+This creates `enigma-logs-YYYYMMDD-HHMMSS.tar.gz` on Linux and macOS, or `enigma-logs-YYYYMMDD-HHMMSS.zip` on Windows, with logs, captures, config, version, and system info. On a packaged install (Linux `.deb` or the Windows installer), `collect-logs` gathers logs, captures, and config from their installed locations regardless of the directory you run it from, while a source checkout still falls back to the `logs/`, `captures/`, and `config.json` in the current directory.
 
 ---
 

--- a/internal/collect_logs/collectlogs.go
+++ b/internal/collect_logs/collectlogs.go
@@ -17,9 +17,45 @@ type archiveBlob struct {
 	Content string
 }
 
+// archiveFile is one on-disk file to add to the archive. Source is the path
+// read from disk; Name is the path recorded inside the archive. Decoupling the
+// two keeps archive member names stable (logs/<basename>, captures/<rel>,
+// config.json) regardless of whether the source is a packaged absolute path or
+// a cwd-relative dev path.
+type archiveFile struct {
+	Source string
+	Name   string
+}
+
 // minArchiveBytes is the floor below which a written archive is treated as
 // hollow rather than valid.
 const minArchiveBytes = 256
+
+// Packaged-install source locations, defaulted from the platform consts. They
+// are package vars so tests can point them at temp paths; they default to the
+// real absolute install paths written by the installer.
+var (
+	installLogDir     = defaultInstallLogDir
+	installCaptureDir = defaultInstallCaptureDir
+	installConfigPath = defaultInstallConfigPath
+)
+
+// resolveDir returns installDir if it is an existing directory, else fallback.
+func resolveDir(installDir, fallback string) string {
+	if info, err := os.Stat(installDir); err == nil && info.IsDir() {
+		return installDir
+	}
+	return fallback
+}
+
+// resolveFile returns installPath if it is an existing regular file, else
+// fallback.
+func resolveFile(installPath, fallback string) string {
+	if info, err := os.Stat(installPath); err == nil && info.Mode().IsRegular() {
+		return installPath
+	}
+	return fallback
+}
 
 // writeArchive is the platform-specific archive writer. It is a variable so
 // tests can substitute a failing or degenerate implementation.
@@ -38,34 +74,43 @@ func CollectLogs(outName string) (size int64, retErr error) {
 		}
 	}()
 
-	// files holds the paths of on-disk files to add to the archive, which are
-	// also used unchanged as the path inside the archive.
-	var files []string
+	// files holds the on-disk source path plus the stable archive member name
+	// for each file to add to the archive.
+	var files []archiveFile
 	var blobs []archiveBlob
 
-	// gatheredBytes counts only real diagnostic content gathered from disk.
-	// The generated version.txt and system-info.txt blobs are deliberately
-	// excluded: they are always present and would mask an otherwise empty
-	// bundle.
-	var gatheredBytes int64
+	// logBytes and captureBytes count runtime diagnostic content; configBytes
+	// counts configuration. They are tracked separately so a bundle carrying
+	// only config (no runtime logs/captures) can be rejected as degraded. The
+	// generated version.txt and system-info.txt blobs are deliberately excluded
+	// from all three: they are always present and would mask an empty bundle.
+	var logBytes, captureBytes, configBytes int64
 
-	// Add all regular files directly in logs/
-	logDir := "logs"
-	if logFiles, err := os.ReadDir(logDir); err == nil { // logs/ may not exist
+	// Resolve each source to its packaged install location when present, else
+	// the cwd-relative dev/source fallback.
+	logDir := resolveDir(installLogDir, "logs")
+	captureDir := resolveDir(installCaptureDir, "captures")
+	configPath := resolveFile(installConfigPath, "config.json")
+
+	// Add all regular files directly in the resolved log dir, under logs/<name>.
+	if logFiles, err := os.ReadDir(logDir); err == nil { // log dir may not exist
 		for _, entry := range logFiles {
 			if entry.IsDir() {
 				continue
 			}
-			path := filepath.Join(logDir, entry.Name())
 			if info, err := entry.Info(); err == nil {
-				gatheredBytes += info.Size()
+				logBytes += info.Size()
 			}
-			files = append(files, path)
+			files = append(files, archiveFile{
+				Source: filepath.Join(logDir, entry.Name()),
+				Name:   "logs/" + entry.Name(),
+			})
 		}
 	}
 
-	// Recursively add all files in captures/ (non-fatal if absent)
-	_ = filepath.WalkDir("captures", func(path string, d os.DirEntry, err error) error {
+	// Recursively add all files under the resolved capture dir, under
+	// captures/<relative-path> (non-fatal if absent).
+	_ = filepath.WalkDir(captureDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -73,24 +118,39 @@ func CollectLogs(outName string) (size int64, retErr error) {
 			return nil
 		}
 		if info, err := d.Info(); err == nil {
-			gatheredBytes += info.Size()
+			captureBytes += info.Size()
 		}
-		files = append(files, path)
+		rel, err := filepath.Rel(captureDir, path)
+		if err != nil {
+			rel = filepath.Base(path)
+		}
+		files = append(files, archiveFile{
+			Source: path,
+			Name:   "captures/" + filepath.ToSlash(rel),
+		})
 		return nil
 	})
 
-	// Add config.json if present
-	if info, err := os.Stat("config.json"); err == nil {
-		gatheredBytes += info.Size()
-		files = append(files, "config.json")
+	// Add the resolved config file if present, under config.json.
+	if info, err := os.Stat(configPath); err == nil {
+		configBytes += info.Size()
+		files = append(files, archiveFile{Source: configPath, Name: "config.json"})
 	}
 
-	if gatheredBytes == 0 {
+	runtimeBytes := logBytes + captureBytes
+
+	if runtimeBytes == 0 && configBytes == 0 {
 		wd, wdErr := os.Getwd()
 		if wdErr != nil {
 			wd = "the current working directory"
 		}
 		return 0, fmt.Errorf("no diagnostic content found in %s: logs/ and captures/ are empty or absent and config.json is missing; run collect-logs from the sensor's working directory (the one holding logs/, captures/, and config.json)", wd)
+	}
+
+	if runtimeBytes == 0 {
+		// Config was found but there are no runtime diagnostics. A config-only
+		// bundle looks complete to support while carrying nothing actionable.
+		return 0, fmt.Errorf("degraded bundle: would contain only config and no runtime diagnostics; both the logs dir (%s) and captures dir (%s) are empty or absent, so there are no logs or captures to collect", logDir, captureDir)
 	}
 
 	blobs = append(blobs,

--- a/internal/collect_logs/collectlogs_installpaths_unix_test.go
+++ b/internal/collect_logs/collectlogs_installpaths_unix_test.go
@@ -1,0 +1,190 @@
+//go:build !windows
+
+package collect_logs
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readTarGzMembers opens a .tar.gz archive and returns a map of member name to
+// its byte content, restricted to regular file entries.
+func readTarGzMembers(t *testing.T, path string) map[string][]byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open archive: %v", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("failed to open gzip reader: %v", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	members := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed to read tar entry: %v", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		buf := make([]byte, hdr.Size)
+		if _, err := io.ReadFull(tr, buf); err != nil {
+			t.Fatalf("failed to read member %s: %v", hdr.Name, err)
+		}
+		members[hdr.Name] = buf
+	}
+	return members
+}
+
+// TestCollectLogs_Unix_PackagedPaths_GatheredRegardlessOfCwd verifies the core
+// fix for issue #71: when the sensor is installed to packaged absolute paths,
+// collect-logs must gather logs, captures (including nested files), and config
+// from those install paths regardless of the current working directory. The
+// in-archive member names stay stable (logs/<basename>,
+// captures/<relative-path>, config.json) even though the on-disk sources live
+// outside the cwd.
+func TestCollectLogs_Unix_PackagedPaths_GatheredRegardlessOfCwd(t *testing.T) {
+	installLog := t.TempDir()
+	installCapture := t.TempDir()
+	configDir := t.TempDir()
+
+	logContent := "installlog-" + strings.Repeat("a", 300)
+	if err := os.WriteFile(filepath.Join(installLog, "enigma.log"), []byte(logContent), 0644); err != nil {
+		t.Fatalf("failed to write install log file: %v", err)
+	}
+
+	captureContent := "installpcap-" + strings.Repeat("p", 300)
+	if err := os.MkdirAll(filepath.Join(installCapture, "session1"), 0755); err != nil {
+		t.Fatalf("failed to create install capture dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installCapture, "session1", "cap.pcap"), []byte(captureContent), 0644); err != nil {
+		t.Fatalf("failed to write install capture file: %v", err)
+	}
+
+	configContent := `{"foo": "` + strings.Repeat("b", 300) + `"}`
+	configPath := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write install config: %v", err)
+	}
+
+	useInstallSources(t, installLog, installCapture, configPath)
+
+	// Run from a DIFFERENT empty cwd with no logs/, captures/, or config.json:
+	// the content must still come from the install paths.
+	t.Chdir(t.TempDir())
+
+	outName := "test-logs.tar.gz"
+	if _, err := CollectLogs(outName); err != nil {
+		t.Fatalf("CollectLogs failed: %v", err)
+	}
+
+	members := readTarGzMembers(t, outName)
+
+	if got := string(members["logs/enigma.log"]); got != logContent {
+		t.Errorf("logs/enigma.log content mismatch: got %q, want %q", got, logContent)
+	}
+	if got := string(members["captures/session1/cap.pcap"]); got != captureContent {
+		t.Errorf("captures/session1/cap.pcap content mismatch: got %q, want %q", got, captureContent)
+	}
+	if got := string(members["config.json"]); got != configContent {
+		t.Errorf("config.json content mismatch: got %q, want %q", got, configContent)
+	}
+}
+
+// TestCollectLogs_Unix_InstallPathPreferredOverCwd verifies that when BOTH the
+// install log dir and a cwd-relative logs/ exist, the install path wins. The
+// install file carries content A and the cwd file carries a different content
+// B under the same basename; the archived logs/<name> must be A.
+func TestCollectLogs_Unix_InstallPathPreferredOverCwd(t *testing.T) {
+	installLog := t.TempDir()
+	contentA := "install-wins-" + strings.Repeat("a", 300)
+	if err := os.WriteFile(filepath.Join(installLog, "enigma.log"), []byte(contentA), 0644); err != nil {
+		t.Fatalf("failed to write install log file: %v", err)
+	}
+
+	// captures/config install sources are absent, so they fall back to cwd
+	// (also absent). logs comes from the install path.
+	base := t.TempDir()
+	useInstallSources(t,
+		installLog,
+		filepath.Join(base, "absent-captures"),
+		filepath.Join(base, "absent-config.json"),
+	)
+
+	t.Chdir(t.TempDir())
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create cwd logs dir: %v", err)
+	}
+	contentB := "cwd-loses-" + strings.Repeat("z", 300)
+	if err := os.WriteFile("logs/enigma.log", []byte(contentB), 0644); err != nil {
+		t.Fatalf("failed to write cwd log file: %v", err)
+	}
+
+	outName := "test-logs.tar.gz"
+	if _, err := CollectLogs(outName); err != nil {
+		t.Fatalf("CollectLogs failed: %v", err)
+	}
+
+	members := readTarGzMembers(t, outName)
+	if got := string(members["logs/enigma.log"]); got != contentA {
+		t.Errorf("expected install log content to win: got %q, want %q", got, contentA)
+	}
+}
+
+// TestCollectLogs_Unix_CwdFallbackWhenInstallAbsent verifies the dev/source-run
+// path: when the packaged install paths do not exist, collect-logs falls back
+// to gathering logs/, captures/, and config.json from the current working
+// directory.
+func TestCollectLogs_Unix_CwdFallbackWhenInstallAbsent(t *testing.T) {
+	t.Chdir(t.TempDir())
+	useCwdSources(t) // install paths point at guaranteed-absent temp paths
+
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	logContent := "cwdlog-" + strings.Repeat("a", 300)
+	if err := os.WriteFile("logs/test.log", []byte(logContent), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
+	if err := os.MkdirAll("captures/session1", 0755); err != nil {
+		t.Fatalf("failed to create captures dir: %v", err)
+	}
+	captureContent := "cwdpcap-" + strings.Repeat("p", 300)
+	if err := os.WriteFile("captures/session1/cap.pcap", []byte(captureContent), 0644); err != nil {
+		t.Fatalf("failed to write pcap file: %v", err)
+	}
+	configContent := `{"foo": "` + strings.Repeat("b", 300) + `"}`
+	if err := os.WriteFile("config.json", []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config.json: %v", err)
+	}
+
+	outName := "test-logs.tar.gz"
+	if _, err := CollectLogs(outName); err != nil {
+		t.Fatalf("CollectLogs failed: %v", err)
+	}
+
+	members := readTarGzMembers(t, outName)
+	if got := string(members["logs/test.log"]); got != logContent {
+		t.Errorf("logs/test.log content mismatch: got %q, want %q", got, logContent)
+	}
+	if got := string(members["captures/session1/cap.pcap"]); got != captureContent {
+		t.Errorf("captures/session1/cap.pcap content mismatch: got %q, want %q", got, captureContent)
+	}
+	if got := string(members["config.json"]); got != configContent {
+		t.Errorf("config.json content mismatch: got %q, want %q", got, configContent)
+	}
+}

--- a/internal/collect_logs/collectlogs_test.go
+++ b/internal/collect_logs/collectlogs_test.go
@@ -3,9 +3,43 @@ package collect_logs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// useCwdSources points the packaged-install source vars at guaranteed-absent
+// paths under a temp dir and restores them in cleanup. Every test MUST control
+// these vars: they default to REAL absolute system paths (e.g.
+// /var/log/enigma-sensor), so a test that leaves them unset could read real
+// host state and become nondeterministic. Calling this forces CollectLogs onto
+// the cwd-relative fallback (logs/, captures/, config.json), which is what the
+// existing tests seed.
+func useCwdSources(t *testing.T) {
+	t.Helper()
+	origLog, origCap, origCfg := installLogDir, installCaptureDir, installConfigPath
+	base := t.TempDir()
+	installLogDir = filepath.Join(base, "absent-install-logs")
+	installCaptureDir = filepath.Join(base, "absent-install-captures")
+	installConfigPath = filepath.Join(base, "absent-install-config.json")
+	t.Cleanup(func() {
+		installLogDir, installCaptureDir, installConfigPath = origLog, origCap, origCfg
+	})
+}
+
+// useInstallSources points the packaged-install source vars at the given
+// (populated) paths and restores them in cleanup, for tests that exercise the
+// absolute install-path resolution.
+func useInstallSources(t *testing.T, logDir, captureDir, configPath string) {
+	t.Helper()
+	origLog, origCap, origCfg := installLogDir, installCaptureDir, installConfigPath
+	installLogDir = logDir
+	installCaptureDir = captureDir
+	installConfigPath = configPath
+	t.Cleanup(func() {
+		installLogDir, installCaptureDir, installConfigPath = origLog, origCap, origCfg
+	})
+}
 
 // seedDiagnosticContent writes a real log file into the current working
 // directory so CollectLogs has actual diagnostic content to gather.
@@ -26,6 +60,7 @@ func seedDiagnosticContent(t *testing.T) {
 func TestCollectLogs_NoDiagnosticContent_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
 	_, err := CollectLogs("test-logs" + ArchiveExt)
 	if err == nil {
@@ -41,17 +76,50 @@ func TestCollectLogs_NoDiagnosticContent_ReturnsError(t *testing.T) {
 	}
 }
 
+// TestCollectLogs_ConfigOnly_Degraded_ReturnsError verifies the degraded-bundle
+// guard: when config.json is present but there are no logs and no captures, the
+// bundle would carry only configuration and no diagnostic runtime content.
+// CollectLogs must reject that condition rather than ship a config-only bundle
+// that looks complete to support, and must not leave an archive on disk.
+func TestCollectLogs_ConfigOnly_Degraded_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	useCwdSources(t)
+
+	// Only a config source, no logs and no captures.
+	if err := os.WriteFile("config.json", []byte(`{"foo": "`+strings.Repeat("c", 300)+`"}`), 0644); err != nil {
+		t.Fatalf("failed to write config.json: %v", err)
+	}
+
+	outName := "test-logs" + ArchiveExt
+	_, err := CollectLogs(outName)
+	if err == nil {
+		t.Fatal("expected CollectLogs to return an error for a config-only (degraded) bundle, got nil")
+	}
+	// The message must convey BOTH that logs and captures were empty AND that
+	// config alone is not enough (the bundle would contain only config).
+	for _, want := range []string{"only", "config", "logs", "captures"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected degraded-bundle error to mention %q, got: %v", want, err)
+		}
+	}
+	if _, statErr := os.Stat(outName); !os.IsNotExist(statErr) {
+		t.Errorf("expected no archive to be left on disk for a degraded bundle, stat err: %v", statErr)
+	}
+}
+
 // TestCollectLogs_ArchiveStepFailure_ReturnsError verifies that CollectLogs
 // surfaces an error (rather than silently succeeding) when the underlying
 // archive-writing step fails.
 func TestCollectLogs_ArchiveStepFailure_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 	seedDiagnosticContent(t)
 
 	original := writeArchive
 	t.Cleanup(func() { writeArchive = original })
-	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+	writeArchive = func(outName string, files []archiveFile, blobs []archiveBlob) (int, error) {
 		return 0, fmt.Errorf("simulated archive write failure")
 	}
 
@@ -70,11 +138,12 @@ func TestCollectLogs_ArchiveStepFailure_ReturnsError(t *testing.T) {
 func TestCollectLogs_ImplausiblySmallArchive_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 	seedDiagnosticContent(t)
 
 	original := writeArchive
 	t.Cleanup(func() { writeArchive = original })
-	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+	writeArchive = func(outName string, files []archiveFile, blobs []archiveBlob) (int, error) {
 		// Simulate a writer that "succeeds" but produces an implausibly
 		// small file (10 bytes).
 		return len(files), os.WriteFile(outName, []byte("tinydata!!"), 0644)
@@ -96,11 +165,12 @@ func TestCollectLogs_ImplausiblySmallArchive_ReturnsError(t *testing.T) {
 func TestCollectLogs_MissingArchive_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 	seedDiagnosticContent(t)
 
 	original := writeArchive
 	t.Cleanup(func() { writeArchive = original })
-	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+	writeArchive = func(outName string, files []archiveFile, blobs []archiveBlob) (int, error) {
 		return len(files), nil // reports success but writes nothing
 	}
 
@@ -116,6 +186,7 @@ func TestCollectLogs_MissingArchive_ReturnsError(t *testing.T) {
 func TestCollectLogs_Success_ReturnsArchiveSize(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
 	if err := os.Mkdir("logs", 0755); err != nil {
 		t.Fatalf("failed to create logs dir: %v", err)
@@ -155,11 +226,12 @@ func TestCollectLogs_Success_ReturnsArchiveSize(t *testing.T) {
 func TestCollectLogs_NoFilesArchived_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 	seedDiagnosticContent(t)
 
 	original := writeArchive
 	t.Cleanup(func() { writeArchive = original })
-	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+	writeArchive = func(outName string, files []archiveFile, blobs []archiveBlob) (int, error) {
 		// Writes a plausibly sized file, but archived none of the gathered
 		// source files.
 		return 0, os.WriteFile(outName, []byte(strings.Repeat("h", 512)), 0644)
@@ -180,11 +252,12 @@ func TestCollectLogs_NoFilesArchived_ReturnsError(t *testing.T) {
 func TestCollectLogs_FailedRun_RemovesArchive(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 	seedDiagnosticContent(t)
 
 	original := writeArchive
 	t.Cleanup(func() { writeArchive = original })
-	writeArchive = func(outName string, files []string, blobs []archiveBlob) (int, error) {
+	writeArchive = func(outName string, files []archiveFile, blobs []archiveBlob) (int, error) {
 		if err := os.WriteFile(outName, []byte(strings.Repeat("h", 512)), 0644); err != nil {
 			return 0, err
 		}

--- a/internal/collect_logs/collectlogs_unix.go
+++ b/internal/collect_logs/collectlogs_unix.go
@@ -13,11 +13,19 @@ import (
 // ArchiveExt is the archive extension used on non-Windows platforms.
 const ArchiveExt = ".tar.gz"
 
+// Packaged-install source paths on non-Windows platforms. These match the
+// locations created by installer/install-enigma-sensor.sh exactly.
+const (
+	defaultInstallLogDir     = "/var/log/enigma-sensor"
+	defaultInstallCaptureDir = "/var/lib/enigma-sensor/captures"
+	defaultInstallConfigPath = "/etc/enigma-sensor/config.json"
+)
+
 // writeArchiveDefault writes a gzip-compressed tar archive containing the
 // given on-disk files and generated blobs. It returns the number of on-disk
 // source files actually written into the archive; the generated blobs are not
 // counted.
-func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (int, error) {
+func writeArchiveDefault(outName string, files []archiveFile, blobs []archiveBlob) (int, error) {
 	out, err := os.Create(outName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create archive file %s: %w", outName, err)
@@ -28,11 +36,11 @@ func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (i
 
 	written := 0
 	writeErr := func() error {
-		for _, path := range files {
-			if err := addFileToTar(tarWriter, path); err != nil {
+		for _, f := range files {
+			if err := addFileToTar(tarWriter, f); err != nil {
 				// Non-fatal: a source file that cannot be archived is skipped.
 				// addFileToTar leaves the tar stream well-formed in that case.
-				fmt.Fprintf(os.Stderr, "warning: skipped %s: %v\n", path, err)
+				fmt.Fprintf(os.Stderr, "warning: skipped %s: %v\n", f.Source, err)
 				continue
 			}
 			written++
@@ -73,8 +81,8 @@ func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (i
 // that could produce a short or long copy is therefore handled here: non-regular
 // files are rejected before the header is written, a file that shrank mid-copy
 // is zero-padded, and a file that grew is truncated to the declared size.
-func addFileToTar(tarWriter *tar.Writer, path string) error {
-	f, err := os.Open(path)
+func addFileToTar(tarWriter *tar.Writer, af archiveFile) error {
+	f, err := os.Open(af.Source)
 	if err != nil {
 		return err
 	}
@@ -85,11 +93,11 @@ func addFileToTar(tarWriter *tar.Writer, path string) error {
 		return err
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("not a regular file: %s", path)
+		return fmt.Errorf("not a regular file: %s", af.Source)
 	}
 
 	hdr := &tar.Header{
-		Name:     path,
+		Name:     af.Name,
 		Mode:     0644,
 		Size:     info.Size(),
 		ModTime:  info.ModTime(),
@@ -104,7 +112,7 @@ func addFileToTar(tarWriter *tar.Writer, path string) error {
 		// The entry is already open in the stream. Pad it out so the archive
 		// stays well-formed, then report the failure so the caller can skip it.
 		if padErr := padTarEntry(tarWriter, hdr.Size-n); padErr != nil {
-			return fmt.Errorf("failed to pad truncated entry %s: %w", path, padErr)
+			return fmt.Errorf("failed to pad truncated entry %s: %w", af.Source, padErr)
 		}
 		return copyErr
 	}
@@ -112,7 +120,7 @@ func addFileToTar(tarWriter *tar.Writer, path string) error {
 		// The file shrank between stat and copy. Pad the remainder with zeros
 		// so the declared size is honoured.
 		if err := padTarEntry(tarWriter, hdr.Size-n); err != nil {
-			return fmt.Errorf("failed to pad shrunken entry %s: %w", path, err)
+			return fmt.Errorf("failed to pad shrunken entry %s: %w", af.Source, err)
 		}
 	}
 	return nil

--- a/internal/collect_logs/collectlogs_unix_test.go
+++ b/internal/collect_logs/collectlogs_unix_test.go
@@ -18,6 +18,7 @@ import (
 func TestCollectLogs_Unix_ArchiveContainsExpectedFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
 	if err := os.Mkdir("logs", 0755); err != nil {
 		t.Fatalf("failed to create logs dir: %v", err)
@@ -101,13 +102,22 @@ func TestCollectLogs_Unix_ArchiveContainsExpectedFiles(t *testing.T) {
 	}
 }
 
-// TestCollectLogs_Unix_MissingDirsAreHandled verifies that when logs/ and
-// captures/ are absent, CollectLogs still succeeds and includes config.json,
-// version.txt, and system-info.txt.
+// TestCollectLogs_Unix_MissingDirsAreHandled verifies that when captures/ is
+// absent, CollectLogs still succeeds and includes logs, config.json,
+// version.txt, and system-info.txt. Runtime content (a log file) is present so
+// the bundle is not degraded; a missing captures/ dir must be tolerated rather
+// than fatal.
 func TestCollectLogs_Unix_MissingDirsAreHandled(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	if err := os.WriteFile("logs/test.log", []byte(strings.Repeat("l", 300)), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
 	if err := os.WriteFile("config.json", []byte(`{"foo": "`+strings.Repeat("c", 300)+`"}`), 0644); err != nil {
 		t.Fatalf("failed to write config.json: %v", err)
 	}
@@ -142,7 +152,7 @@ func TestCollectLogs_Unix_MissingDirsAreHandled(t *testing.T) {
 		found[hdr.Name] = true
 	}
 
-	for _, want := range []string{"config.json", "version.txt", "system-info.txt"} {
+	for _, want := range []string{"logs/test.log", "config.json", "version.txt", "system-info.txt"} {
 		if !found[want] {
 			t.Errorf("expected %s in archive, not found", want)
 		}
@@ -157,6 +167,7 @@ func TestCollectLogs_Unix_MissingDirsAreHandled(t *testing.T) {
 func TestCollectLogs_Unix_NonRegularCaptureEntry_DoesNotCorruptArchive(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
 	if err := os.Mkdir("logs", 0755); err != nil {
 		t.Fatalf("failed to create logs dir: %v", err)

--- a/internal/collect_logs/collectlogs_windows.go
+++ b/internal/collect_logs/collectlogs_windows.go
@@ -12,10 +12,29 @@ import (
 // ArchiveExt is the archive extension used on Windows.
 const ArchiveExt = ".zip"
 
+// Packaged-install source paths on Windows.
+//
+// Only config.json has a fixed absolute home: the installer
+// (installer/windows/enigma-sensor-installer.iss) copies config.example.json
+// verbatim to C:\ProgramData\EnigmaSensor\config.json, changing only
+// api_key/network_id. That config keeps relative paths for everything else
+// (capture.output_dir = "./captures", logging.file = "logs/enigma-sensor.log").
+// The service runs via NSSM with AppDirectory set to the install dir
+// (C:\Program Files\EnigmaSensor), so at runtime the process cwd is the
+// install dir, not ProgramData. Leaving the log and capture dirs empty here
+// means resolveDir falls through to its cwd-relative fallback ("logs",
+// "captures"), which resolves against that install-dir cwd and matches
+// where the running service actually writes.
+const (
+	defaultInstallLogDir     = ``
+	defaultInstallCaptureDir = ``
+	defaultInstallConfigPath = `C:\ProgramData\EnigmaSensor\config.json`
+)
+
 // writeArchiveDefault writes a zip archive containing the given on-disk files
 // and generated blobs. It returns the number of on-disk source files actually
 // written into the archive; the generated blobs are not counted.
-func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (int, error) {
+func writeArchiveDefault(outName string, files []archiveFile, blobs []archiveBlob) (int, error) {
 	out, err := os.Create(outName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create archive file %s: %w", outName, err)
@@ -25,10 +44,10 @@ func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (i
 
 	written := 0
 	writeErr := func() error {
-		for _, path := range files {
-			if err := addFileToZip(zipWriter, path); err != nil {
+		for _, f := range files {
+			if err := addFileToZip(zipWriter, f); err != nil {
 				// Non-fatal: a source file that cannot be archived is skipped.
-				fmt.Fprintf(os.Stderr, "warning: skipped %s: %v\n", path, err)
+				fmt.Fprintf(os.Stderr, "warning: skipped %s: %v\n", f.Source, err)
 				continue
 			}
 			written++
@@ -57,8 +76,8 @@ func writeArchiveDefault(outName string, files []string, blobs []archiveBlob) (i
 	return written, nil
 }
 
-func addFileToZip(zipWriter *zip.Writer, path string) error {
-	f, err := os.Open(path)
+func addFileToZip(zipWriter *zip.Writer, af archiveFile) error {
+	f, err := os.Open(af.Source)
 	if err != nil {
 		return err
 	}
@@ -69,10 +88,10 @@ func addFileToZip(zipWriter *zip.Writer, path string) error {
 		return err
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("not a regular file: %s", path)
+		return fmt.Errorf("not a regular file: %s", af.Source)
 	}
 
-	w, err := zipWriter.Create(path)
+	w, err := zipWriter.Create(af.Name)
 	if err != nil {
 		return err
 	}

--- a/internal/collect_logs/collectlogs_windows_test.go
+++ b/internal/collect_logs/collectlogs_windows_test.go
@@ -15,6 +15,7 @@ import (
 func TestCollectLogs_Windows_CreatesZipWithExpectedFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
 	// Setup: create logs/, captures/, config.json
 	if err := os.Mkdir("logs", 0755); err != nil {
@@ -67,13 +68,22 @@ func TestCollectLogs_Windows_CreatesZipWithExpectedFiles(t *testing.T) {
 	}
 }
 
-// TestCollectLogs_Windows_MissingDirsAreHandled ports the original coverage
-// for the case where only config.json is present.
+// TestCollectLogs_Windows_MissingDirsAreHandled verifies that a missing
+// captures/ dir is tolerated: with a log file and config.json present (runtime
+// content exists, so the bundle is not degraded), CollectLogs still succeeds
+// and includes logs, config.json, version.txt, and system-info.txt.
 func TestCollectLogs_Windows_MissingDirsAreHandled(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
-	// Only create config.json
+	// Create logs/ (runtime content) and config.json; captures/ stays absent.
+	if err := os.Mkdir("logs", 0755); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	if err := os.WriteFile("logs/test.log", []byte(strings.Repeat("l", 300)), 0644); err != nil {
+		t.Fatalf("failed to write log file: %v", err)
+	}
 	if err := os.WriteFile("config.json", []byte(`{"foo": "`+strings.Repeat("c", 300)+`"}`), 0644); err != nil {
 		t.Fatalf("failed to write config.json: %v", err)
 	}
@@ -96,9 +106,12 @@ func TestCollectLogs_Windows_MissingDirsAreHandled(t *testing.T) {
 	}
 	defer r.Close()
 
-	var foundConfig, foundVersion, foundSysinfo bool
+	var foundLog, foundConfig, foundVersion, foundSysinfo bool
 	for _, f := range r.File {
 		normalized := strings.ReplaceAll(f.Name, "\\", "/")
+		if normalized == "logs/test.log" {
+			foundLog = true
+		}
 		if normalized == "config.json" {
 			foundConfig = true
 		}
@@ -109,8 +122,8 @@ func TestCollectLogs_Windows_MissingDirsAreHandled(t *testing.T) {
 			foundSysinfo = true
 		}
 	}
-	if !foundConfig || !foundVersion || !foundSysinfo {
-		t.Errorf("Expected config.json, version.txt, and system-info.txt in zip (got: %v)", r.File)
+	if !foundLog || !foundConfig || !foundVersion || !foundSysinfo {
+		t.Errorf("Expected logs/test.log, config.json, version.txt, and system-info.txt in zip (got: %v)", r.File)
 	}
 }
 
@@ -121,6 +134,7 @@ func TestCollectLogs_Windows_MissingDirsAreHandled(t *testing.T) {
 func TestCollectLogs_Windows_EmptyDirs_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	useCwdSources(t)
 
 	if err := os.Mkdir("logs", 0755); err != nil {
 		t.Fatalf("failed to create logs dir: %v", err)


### PR DESCRIPTION
On a packaged install, `collect-logs` read `logs/`, `captures/`, and `config.json` relative to the current directory, so the support bundle came out empty or held only `config.json` (the new hollow-bundle guard passed it because config alone cleared the size floor).

This resolves each source to its installed absolute location when present (`/var/log/enigma-sensor`, `/var/lib/enigma-sensor/captures`, `/etc/enigma-sensor/config.json` on Linux), keeping the cwd-relative path as a dev/source fallback. Archive member names stay stable (`logs/`, `captures/`, `config.json`) regardless of where the source lives. A config-only bundle with no logs or captures is now treated as degraded and fails loudly.

On Windows only `config.json` has a fixed absolute home (`C:\ProgramData\EnigmaSensor\config.json`); the service runs with its cwd set to the install dir, so logs and captures resolve correctly through the cwd fallback.

Closes #71